### PR TITLE
GPII-1239: Work around reuse of PouchDB between test cases...

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "node src/tests/all-tests.js"
+    "test": "node src/tests/all-tests.js",
+    "postinstall": "grunt dedupe-infusion"
   },
   "dependencies": {
     "express": "4.10.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "node src/tests/all-tests.js",
+    "test": "node tests/js/all-tests.js",
     "postinstall": "grunt dedupe-infusion"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "express": "4.10.5",
     "express-pouchdb": "0.14.0",
+    "gpii-express": "git://github.com/GPII/gpii-express#d2b57d7920270926a0fad77c81a39541a2a1a6e6",
     "infusion": "git://github.com/fluid-project/infusion.git#df5f8cfabf815a4086b778e73125c3c952dda4ec",
     "memdown": "1.0.0",
     "pouchdb": "3.3.1",
@@ -15,7 +16,6 @@
     "when": "^3.7.3"
   },
   "devDependencies": {
-    "gpii-express": "git://github.com/GPII/gpii-express#d2b57d7920270926a0fad77c81a39541a2a1a6e6",
     "grunt": "~0.4.4",
     "grunt-shell": "0.6.4",
     "grunt-contrib-jshint": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -6,23 +6,24 @@
     "test": "node src/tests/all-tests.js"
   },
   "dependencies": {
-    "express":         "4.10.5",
+    "express": "4.10.5",
     "express-pouchdb": "0.14.0",
-    "infusion":        "git://github.com/fluid-project/infusion.git#df5f8cfabf815a4086b778e73125c3c952dda4ec",
-    "memdown":         "1.0.0",
-    "pouchdb":         "3.3.1",
-    "underscore-node": "0.1.2"
+    "infusion": "git://github.com/fluid-project/infusion.git#df5f8cfabf815a4086b778e73125c3c952dda4ec",
+    "memdown": "1.0.0",
+    "pouchdb": "3.3.1",
+    "underscore-node": "0.1.2",
+    "when": "^3.7.3"
   },
   "devDependencies": {
-    "gpii-express":         "git://github.com/GPII/gpii-express#d2b57d7920270926a0fad77c81a39541a2a1a6e6",
-    "grunt":                "~0.4.4",
-    "grunt-shell":          "0.6.4",
+    "gpii-express": "git://github.com/GPII/gpii-express#d2b57d7920270926a0fad77c81a39541a2a1a6e6",
+    "grunt": "~0.4.4",
+    "grunt-shell": "0.6.4",
     "grunt-contrib-jshint": "~0.9.0",
-    "grunt-jsonlint":       "1.0.4",
-    "grunt-gpii":           "git://github.com/GPII/grunt-gpii.git#58ae055833f437a9e91baedb9f39a22c5fdd727f",
-    "jqUnit":               "git://github.com/fluid-project/node-jqUnit.git#e9bf72445bd343a4f3aabe3ba96a1087d3498612",
-    "kettle":               "git://github.com/fluid-project/kettle.git#e79bb81196df68c97eaa9f96c485a4321b69af75",
-    "request":              "2.51.0",
-    "tough-cookie":         "0.12.1"
+    "grunt-jsonlint": "1.0.4",
+    "grunt-gpii": "git://github.com/GPII/grunt-gpii.git#58ae055833f437a9e91baedb9f39a22c5fdd727f",
+    "jqUnit": "git://github.com/fluid-project/node-jqUnit.git#e9bf72445bd343a4f3aabe3ba96a1087d3498612",
+    "kettle": "git://github.com/fluid-project/kettle.git#e79bb81196df68c97eaa9f96c485a4321b69af75",
+    "request": "2.51.0",
+    "tough-cookie": "0.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-jsonlint":       "1.0.4",
     "grunt-gpii":           "git://github.com/GPII/grunt-gpii.git#58ae055833f437a9e91baedb9f39a22c5fdd727f",
     "jqUnit":               "git://github.com/fluid-project/node-jqUnit.git#e9bf72445bd343a4f3aabe3ba96a1087d3498612",
+    "kettle":               "git://github.com/fluid-project/kettle.git#e79bb81196df68c97eaa9f96c485a4321b69af75",
     "request":              "2.51.0",
     "tough-cookie":         "0.12.1"
   }

--- a/src/js/pouch.js
+++ b/src/js/pouch.js
@@ -85,6 +85,10 @@ gpii.pouch.getRouter = function (that) {
 gpii.pouch.cleanup = function (that) {
     var promises = [];
     fluid.each(that.databaseInstances, function (db, key) {
+            // If we use the simpler method, the next attempt to recreate the database fails with a 409 document update conflict.
+            //var promise = db.destroy();
+
+            // Instead, we retrieve the list of all document IDs and revisions, and then bulk delete them.
             var promise = db.allDocs()
                 .then(function (result) {
                     var bulkPayloadDocs = fluid.transform(result.rows, gpii.pouch.transformRecord);

--- a/src/js/pouch.js
+++ b/src/js/pouch.js
@@ -1,4 +1,24 @@
-// Utility functions to add pouch to an existing express instance
+// Provide a CouchDB-like API using `PouchDB` and `express-pouchdb`.  This in only useful in association with an
+// existing `gpii.express` instance.
+//
+// The "databases" option is expected to be an array keyed by dbName, with options to control whether data is loaded or
+// not, as in:
+//
+//  databases: {
+//    "nodata": {},
+//    "data":   { "data": "../tests/data/records.json" }
+//  }
+//
+// In this example, an empty database called "nodata" would be created, and a database called "data" would be created
+// and populated with the contents of "../tests/data/records.json".
+//
+// NOTE:
+//   This module has a serious and non-obvious limitation, in that only one instance of PouchDB is created.  This
+//   means that multiple test sequences may end up using the same databases.  If you use the same database names in
+//   different test sequences, you may end up having the same data loaded multiple times.  To avoid this, either use
+//   different database names, or specify an _id value for every record you are creating.
+//
+// TODO:  Examine ways to fix this within PouchDB or otherwise address.  See: https://issues.gpii.net/browse/GPII-1239
 "use strict";
 var fluid = require("infusion");
 var gpii  = fluid.registerNamespace("gpii");
@@ -7,18 +27,17 @@ fluid.registerNamespace("gpii.pouch");
 var os             = require("os");
 var path           = require("path");
 var fs             = require("fs");
+var when           = require("when");
+
+var expressPouchdb = require("express-pouchdb");
+var PouchDB        = require("pouchdb");
+var memdown        = require("memdown");
 
 // We want to output our generated config file to the temporary directory instead of the working directory.
 var pouchConfigPath = path.resolve(os.tmpdir(), "config.json");
 var pouchLogPath    = path.resolve(os.tmpdir(), "log.txt");
 
-
 gpii.pouch.init = function (that) {
-    // These cannot be a global variables or we will end up passing data between test runs and other bad stuff.
-    var expressPouchdb = require("express-pouchdb");
-    var PouchDB        = require("pouchdb");
-    var memdown        = require("memdown");
-
     // There are unfortunately options that can only be configured via a configuration file.
     //
     // To allow ourselves (and users configuring and extending this grade) to control these options, we create the file
@@ -27,50 +46,82 @@ gpii.pouch.init = function (that) {
     fs.writeFileSync(that.options.pouchConfigPath, JSON.stringify(that.options.pouchConfig, null, 2));
 
     var MemPouchDB = PouchDB.defaults({ db: memdown });
-
-    fluid.each(that.options.databases, function (dbConfig, key) {
-        var db = new MemPouchDB(key);
-        if (dbConfig.data) {
-            var data = require(dbConfig.data);
-            db.bulkDocs(data);
-        }
-        that.dbs.push(db);
-    });
-
     that.expressPouchdb = expressPouchdb(MemPouchDB, { configPath: pouchConfigPath });
 
-    that.events.onStarted.fire();
+    if (PouchDB.isBeingCleaned) {
+        var timedOut = false;
+
+        var failIfPouchTakesTooLong = setTimeout(function () {
+            timedOut = true;
+            fluid.fail("Pouch never finished being cleaned up from the last run...");
+        }, 2500);
+
+        var checkToSeeIfPouchIsClean = setInterval(function () {
+            if (PouchDB.isBeingCleaned) {
+                fluid.log("Waiting for pouch to clean up from previous run...");
+            }
+            else {
+                clearInterval(checkToSeeIfPouchIsClean);
+
+                if (timedOut) {
+                    fluid.log("Pouch cleanup timed out, cannot continue initializing new instance...");
+                }
+                else {
+                    clearTimeout(failIfPouchTakesTooLong);
+                    gpii.pouch.loadData(that, MemPouchDB);
+                }
+            }
+        }, 500);
+    }
+    else {
+        gpii.pouch.loadData(that, MemPouchDB);
+    }
+};
+
+gpii.pouch.loadData = function (that, MemPouchDB) {
+    if (PouchDB.isBeingCleaned) {
+        fluid.fail("I should never be allowed to load data if pouch is still being cleaned from the previous run...");
+    }
+    else {
+        var promises = [];
+        fluid.each(that.options.databases, function (dbConfig, key) {
+            var db = new MemPouchDB(key);
+            that.databases.push(db);
+
+            if (dbConfig.data) {
+                var data = require(dbConfig.data);
+                promises.push(db.bulkDocs(data));
+            }
+        });
+
+        when.all(promises).then(function () {
+            that.events.onStarted.fire();
+        });
+    }
 };
 
 gpii.pouch.getRouter = function (that) {
     return that.expressPouchdb;
 };
 
-// Clean up after MemDown when we are being destroyed.  This avoids problems where previous cached data is visible in future runs.
+// Destroy our databases when we are being destroyed.  This is meant to avoid problems where previous cached data is
+// visible in future runs.  See https://issues.gpii.net/browse/GPII-1239 for details.
 gpii.pouch.destroyDbs = function (that) {
-    fluid.each(that.dbs, function (db) {
-        //db.destroy();
+    PouchDB.isBeingCleaned = true;
+    var promises = [];
+    fluid.each(that.databases, function (db) {
+        promises.push(db.destroy());
+    });
+    when.all(promises).then(function () {
+        PouchDB.isBeingCleaned = false;
     });
 };
 
-// TODO:  Write a change listener to allow easy adding of new databases
-
-/*
-    The "databases" option is expected to be an array keyed by dbName, with options to control whether data is loaded or not, as in:
-
-    databases: {
-        "nodata": {},
-        "data":   { "data": "../tests/data/records.json" }
-    }
- */
 fluid.defaults("gpii.pouch", {
-    gradeNames:      ["fluid.standardRelayComponent", "gpii.express.router", "autoInit"],
-    config:          "{gpii.express}.options.config",
+    gradeNames:       ["fluid.standardRelayComponent", "gpii.express.router", "autoInit"],
+    config:           "{gpii.express}.options.config",
     path:             "/",
-    members: {
-        dbs: []
-    },
-    pouchConfigPath: pouchConfigPath,
+    pouchConfigPath:  pouchConfigPath,
     pouchConfig: {
         log: {
             file: pouchLogPath
@@ -78,6 +129,9 @@ fluid.defaults("gpii.pouch", {
     },
     events: {
         onStarted: null
+    },
+    members: {
+        databases: []
     },
     databases: {},
     listeners: {

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1,3 +1,3 @@
 {
-  "docs": [ { "_id": "foo", "foo": "bar" }, {"_id": "https://issues.gpii.net/browse/GPII-1239", "baz": "qux"}, { "_id": "todelete", "foo": "bar"} ]
+  "docs": [ { "foo": "bar" }, {"_id": "https://issues.gpii.net/browse/GPII-1239", "baz": "qux"}, { "_id": "todelete", "foo": "bar"} ]
 }

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1,3 +1,3 @@
 {
-  "docs": [ { "foo": "bar" }, {"_id": "https://issues.gpii.net/browse/GPII-1239", "baz": "qux"}, { "_id": "todelete", "foo": "bar"} ]
+  "docs": [ { "_id": "foo", "foo": "bar" }, {"baz": "qux"}, { "_id": "todelete", "foo": "bar"} ]
 }

--- a/tests/data/data.json
+++ b/tests/data/data.json
@@ -1,3 +1,3 @@
 {
-  "docs": [ { "_id": "foo", "foo": "bar" }, {"baz": "qux"}, { "_id": "todelete", "foo": "bar"} ]
+  "docs": [ { "_id": "foo", "foo": "bar" }, {"_id": "https://issues.gpii.net/browse/GPII-1239", "baz": "qux"}, { "_id": "todelete", "foo": "bar"} ]
 }

--- a/tests/js/all-tests.js
+++ b/tests/js/all-tests.js
@@ -1,0 +1,6 @@
+// Run all tests in this package in series.
+"use strict";
+var fluid = fluid || require("infusion");
+
+require("./basic-tests");
+require("./reload-tests");

--- a/tests/js/basic-tests.js
+++ b/tests/js/basic-tests.js
@@ -8,9 +8,9 @@ var request    = require("request");
 
 require("gpii-express");
 
-require("../src/js/pouch.js");
+require("../../src/js/pouch.js");
 
-require("../node_modules/gpii-express/tests/js/test-helpers");
+require("../../node_modules/gpii-express/tests/js/test-helpers");
 
 fluid.registerNamespace("gpii.tests.pouchdb");
 gpii.tests.pouchdb.isSaneRecordBody = function (body, disableOkCheck) {

--- a/tests/js/basic-tests.js
+++ b/tests/js/basic-tests.js
@@ -1,148 +1,312 @@
 /* Tests for the "pouch" module */
 "use strict";
 var fluid      = fluid || require("infusion");
+fluid.setLogging(true);
+
 var gpii       = fluid.registerNamespace("gpii");
-var path       = require("path");
 var jqUnit     = fluid.require("jqUnit");
-var request    = require("request");
-
-require("gpii-express");
-
-require("../../src/js/pouch.js");
 
 require("../../node_modules/gpii-express/tests/js/test-helpers");
 
-fluid.registerNamespace("gpii.tests.pouchdb");
-gpii.tests.pouchdb.isSaneRecordBody = function (body, disableOkCheck) {
-    var data = typeof body === "string" ? JSON.parse(body) : body;
+// We use just the request-handling bits of the kettle stack in our tests, but we include the whole thing to pick up the base grades
+require("../../node_modules/kettle");
+require("../../node_modules/kettle/lib/test/KettleTestUtils");
 
-    if (!disableOkCheck) {
-        jqUnit.assertTrue("The response should be OK.", data.ok);
+require("./harness");
+require("../lib/sequence");
+
+// Convenience grade to avoid putting the same settings into all of our request components
+fluid.defaults("gpii.pouch.tests.basic.request", {
+    gradeNames: ["kettle.test.request.http", "autoInit"],
+    port:       "{testEnvironment}.options.port",
+    method:     "GET"
+});
+
+fluid.registerNamespace("gpii.pouch.tests.basic");
+gpii.pouch.tests.basic.checkResponse = function (response, body, expectedStatus, expectedBody) {
+    expectedStatus = expectedStatus ? expectedStatus : 200;
+
+    var bodyData = JSON.parse(body);
+
+    gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body, expectedStatus);
+
+    // NOTE:  This only works for results where you know the exact response or a simple subset.  Deeply inserted
+    // "couchisms" such as record `_id` and `_rev` values must be checked separately.  See the tests in gpii-pouchdb-lucene for an example.
+    if (expectedBody) {
+        jqUnit.assertLeftHand("The body should be as expected...", expectedBody, bodyData);
     }
-
-    var id = data.id ? data.id : data._id;
-    jqUnit.assertTrue("There should be id data.", id  !== null && id  !== undefined);
-
-    var rev = data.rev ? data.id : data._rev;
-    jqUnit.assertTrue("There should be revision data.", rev !== null && rev !== undefined);
 };
 
-gpii.tests.pouchdb.hasRecords = function (body) {
-    var data = (typeof body === "string") ? JSON.parse(body) : body;
-    return data.doc_count && data.doc_count > 0;
-};
+//    jqUnit.asyncTest("Testing insertion of a new record...", function () {
+//        var options = {
+//            url:  that.options.baseUrl + "sample",
+//            json: { "foo": "bar" }
+//        };
+//        request.post(options, function (error, response, body) {
+//            jqUnit.start();
+//            gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body, 201);
+//            gpii.tests.pouchdb.isSaneRecordBody(body);
+//        });
+//    });
 
-var sampleDataFile  = path.resolve(__dirname, "./data/data.json");
-var userDataFile    = path.resolve(__dirname, "./data/users.json");
-
-// A ~100k data set to confirm that the async data loads do not take too long.
-var massiveDataFile = path.resolve(__dirname, "./data/massive.json");
-
-var pouch = gpii.express({
-    "config": {
-        "express": {
-            "port" :   7532,
-            "baseUrl": "http://localhost:7532/"
-        }
+fluid.defaults("gpii.pouch.tests.basic.caseHolder", {
+    gradeNames: ["fluid.test.testCaseHolder", "autoInit"],
+    expected: {
+        root:         { "express-pouchdb": "Welcome!" },
+        massive:      { total_rows: 150 },
+        noData:       { total_rows: 0 },
+        read:         { foo: "bar" },
+        "delete":     {},
+        insert:       { id: "toinsert", foo: "bar"}
     },
-    components: {
-        "pouch": {
-            type: "gpii.pouch",
-            options: {
-                "databases": {
-                    "_users":  { "data": userDataFile   },
-                    "data":    { "data": sampleDataFile },
-                    "massive": { "data": massiveDataFile},
-                    "nodata":  {}
+    mergePolicy: {
+        rawModules:    "noexpand",
+        sequenceStart: "noexpand"
+    },
+    moduleSource: {
+        funcName: "gpii.pouch.tests.addRequiredSequences",
+        args:     ["{that}.options.sequenceStart", "{that}.options.rawModules"]
+    },
+    sequenceStart: [
+        { // This sequence point is required because of a QUnit bug - it defers the start of sequence by 13ms "to avoid any current callbacks" in its words
+            func: "{testEnvironment}.events.constructServer.fire"
+        },
+        {
+            listener: "fluid.identity",
+            event:    "{testEnvironment}.events.onReady"
+        }
+    ],
+    // Our raw test cases, that will have `sequenceStart` prepended before they are run.
+    rawModules: [
+        {
+            tests: [
+                {
+                    name: "Testing loading pouch root...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{rootRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{rootRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{rootRequest}.nativeResponse", "{arguments}.0", 200, "{testCaseHolder}.options.expected.root"]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing 'massive' database...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{massiveRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{massiveRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{massiveRequest}.nativeResponse", "{arguments}.0", 200, "{testCaseHolder}.options.expected.massive"]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing 'nodata' database...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{noDataRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{noDataRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{noDataRequest}.nativeResponse", "{arguments}.0", 200, "{testCaseHolder}.options.expected.noData"]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing reading a single record from the 'sample' database...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{readRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{readRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{readRequest}.nativeResponse", "{arguments}.0", 200, "{testCaseHolder}.options.expected.read"]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing deleting a single record from the 'sample' database...",
+                    type: "test",
+                    sequence: [
+                        // The record should exist before we delete it.
+                        {
+                            func: "{preDeleteRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{preDeleteRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{preDeleteRequest}.nativeResponse", "{arguments}.0", 200]
+                        },
+                        // The delete should be successful.
+                        {
+                            func: "{deleteRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{deleteRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{deleteRequest}.nativeResponse", "{arguments}.0", 200, "{testCaseHolder}.options.expected.delete"]
+                        },
+                        // The record should no longer exist after we delete it.
+                        {
+                            func: "{verifyDeleteRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{verifyDeleteRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{verifyDeleteRequest}.nativeResponse", "{arguments}.0", 404]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing inserting a record into the 'sample' database...",
+                    type: "test",
+                    sequence: [
+                        // The record should not exist before we create it.
+                        {
+                            func: "{preInsertRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{preInsertRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{preInsertRequest}.nativeResponse", "{arguments}.0", 404]
+                        },
+                        // The insert should be successful.
+                        {
+                            func: "{insertRequest}.send",
+                            args: "{that}.options.expected.insert"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{insertRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{insertRequest}.nativeResponse", "{arguments}.0", 201]
+                        },
+                        // The record should exist after we create it.
+                        {
+                            func: "{verifyInsertRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.basic.checkResponse",
+                            event:    "{verifyInsertRequest}.events.onComplete",
+                            //        (response, body, expectedStatus, expectedBody)
+                            args:     ["{verifyInsertRequest}.nativeResponse", "{arguments}.0", 200, "{testCaseHolder}.options.expected.insert"]
+                        }
+                    ]
                 }
+            ]
+        }
+    ],
+    components: {
+        rootRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path: "/"
+            }
+        },
+        massiveRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path: "/massive/_all_docs"
+            }
+        },
+        noDataRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path: "/nodata/_all_docs"
+            }
+        },
+        readRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path: "/sample/foo"
+            }
+        },
+        preDeleteRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path: "/sample/todelete"
+            }
+        },
+        deleteRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path:   "/sample/todelete",
+                method: "DELETE"
+            }
+        },
+        verifyDeleteRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path: "/sample/todelete"
+            }
+        },
+        preInsertRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path:   "/sample/toinsert"
+            }
+        },
+        insertRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path:   "/sample/toinsert",
+                method: "PUT"
+            }
+        },
+        verifyInsertRequest: {
+            type: "gpii.pouch.tests.basic.request",
+            options: {
+                path:   "/sample/toinsert"
             }
         }
+
     }
 });
 
-
-jqUnit.module("Testing pouch module stack...");
-
-jqUnit.asyncTest("Testing the 'massive' database (should contain data)...", function () {
-    var options = {
-        url: pouch.options.config.express.baseUrl + "massive"
-    };
-    request.get(options, function (error, response, body) {
-        jqUnit.start();
-        gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body);
-
-        jqUnit.assertTrue("There should be records.", gpii.tests.pouchdb.hasRecords(body));
-    });
+fluid.defaults("gpii.pouch.tests.basic.environment", {
+    gradeNames: ["fluid.test.testEnvironment", "autoInit"],
+    port:       6798,
+    baseUrl:    "/",
+    events: {
+        constructServer: null,
+        onReady: null
+    },
+    components: {
+        harness: {
+            type: "gpii.pouch.tests.harness",
+            createOnEvent: "constructServer",
+            options: {
+                port:       "{testEnvironment}.options.port",
+                baseUrl:    "{testEnvironment}.options.baseUrl",
+                listeners: {
+                    onReady: "{testEnvironment}.events.onReady.fire"
+                }
+            }
+        },
+        testCaseHolder: {
+            type: "gpii.pouch.tests.basic.caseHolder"
+        }
+    }
 });
 
-jqUnit.asyncTest("Testing the root of the pouch instance...", function () {
-    var options = {
-        url: pouch.options.config.express.baseUrl
-    };
-    request.get(options, function (error, response, body) {
-        jqUnit.start();
-        gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body);
-    });
-});
-
-jqUnit.asyncTest("Testing the 'nodata' database (should not contain data)...", function () {
-    var options = {
-        url: pouch.options.config.express.baseUrl + "nodata"
-    };
-    request.get(options, function (error, response, body) {
-        jqUnit.start();
-        gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body);
-
-        jqUnit.assertFalse("There should be no records.", gpii.tests.pouchdb.hasRecords(body));
-    });
-});
-
-jqUnit.asyncTest("Testing the 'data' database (should contain data)...", function () {
-    var options = {
-        url: pouch.options.config.express.baseUrl + "data"
-    };
-    request.get(options, function (error, response, body) {
-        jqUnit.start();
-        gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body);
-
-        jqUnit.assertTrue("There should be records.", gpii.tests.pouchdb.hasRecords(body));
-    });
-});
-
-// TODO:  test inserts
-jqUnit.asyncTest("Testing insertion of a new record...", function () {
-    var options = {
-        url:  pouch.options.config.express.baseUrl + "data",
-        json: { "foo": "bar" }
-    };
-    request.post(options, function (error, response, body) {
-        jqUnit.start();
-        gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body, 201);
-        gpii.tests.pouchdb.isSaneRecordBody(body);
-    });
-});
-
-jqUnit.asyncTest("Testing reading of a record...", function () {
-    var options = {
-        url:  pouch.options.config.express.baseUrl + "data/foo"
-    };
-    request.get(options, function (error, response, body) {
-        jqUnit.start();
-        gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body);
-        gpii.tests.pouchdb.isSaneRecordBody(body, true);
-
-        var data = (typeof body === "string") ? JSON.parse(body) : body;
-        jqUnit.assertEquals("There should be document data.", "bar", data.foo);
-    });
-});
-
-jqUnit.asyncTest("Testing deletion of a record...", function () {
-    var options = {
-        url:  pouch.options.config.express.baseUrl + "data/todelete"
-    };
-    request.del(options, function (error, response, body) {
-        jqUnit.start();
-        gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body);
-        gpii.tests.pouchdb.isSaneRecordBody(body);
-    });
-});
+gpii.pouch.tests.basic.environment();

--- a/tests/js/harness.js
+++ b/tests/js/harness.js
@@ -8,6 +8,10 @@ require("../../src/js/pouch");
 
 var path = require("path");
 var sampleDataFile = path.resolve(__dirname, "../data/data.json");
+var userDataFile    = path.resolve(__dirname, "../data/users.json");
+
+// A ~100k data set to confirm that the async data loads do not take too long.
+var massiveDataFile = path.resolve(__dirname, "../data/massive.json");
 
 fluid.defaults("gpii.pouch.tests.harness", {
     gradeNames: ["fluid.eventedComponent", "autoInit"],
@@ -46,7 +50,10 @@ fluid.defaults("gpii.pouch.tests.harness", {
                         options: {
                             path: "/",
                             databases: {
-                                sample:  { data: sampleDataFile }
+                                sample:  { data: sampleDataFile },
+                                _users:  { data: userDataFile},
+                                massive: { data: massiveDataFile},
+                                nodata:  {}
                             },
                             listeners: {
                                 onStarted: "{harness}.events.pouchStarted.fire"
@@ -58,3 +65,4 @@ fluid.defaults("gpii.pouch.tests.harness", {
         }
     }
 });
+

--- a/tests/js/harness.js
+++ b/tests/js/harness.js
@@ -1,0 +1,60 @@
+// Common test harness for use both in tests and for manual QA.  To use for manual QA, run the `launch-test-harness.js`
+// script in this directory.
+"use strict";
+var fluid = fluid || require("infusion");
+
+require("gpii-express");
+require("../../src/js/pouch");
+
+var path = require("path");
+var sampleDataFile = path.resolve(__dirname, "../data/data.json");
+
+fluid.defaults("gpii.pouch.tests.harness", {
+    gradeNames: ["fluid.eventedComponent", "autoInit"],
+    port:       6789,
+    baseUrl:    "http://localhost:6789/",
+    events: {
+        expressStarted: null,
+        pouchStarted:   null,
+        onReady: {
+            events: {
+                expressStarted: "expressStarted",
+                pouchStarted:   "pouchStarted"
+            }
+        }
+    },
+    components: {
+        pouch: {
+            type: "gpii.express",
+            options: {
+                config: {
+                    express: {
+                        "port" : "{harness}.options.port",
+                        baseUrl: "{harness}.options.baseUrl"
+                    },
+                    app: {
+                        name: "Pouch Test Server",
+                        url:  "{harness}.options.baseUrl"
+                    }
+                },
+                listeners: {
+                    onStarted: "{harness}.events.expressStarted.fire"
+                },
+                components: {
+                    pouch: {
+                        type: "gpii.pouch",
+                        options: {
+                            path: "/",
+                            databases: {
+                                sample:  { data: sampleDataFile }
+                            },
+                            listeners: {
+                                onStarted: "{harness}.events.pouchStarted.fire"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+});

--- a/tests/js/launch-test-harness.js
+++ b/tests/js/launch-test-harness.js
@@ -1,0 +1,10 @@
+// A convenience script to start the test harness, used for manual QA.
+"use strict";
+var fluid = fluid || require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+require("./harness");
+
+fluid.setLogging(true);
+
+gpii.pouch.tests.harness();

--- a/tests/js/reload-tests.js
+++ b/tests/js/reload-tests.js
@@ -1,0 +1,124 @@
+// Confirming that pouch can safely be loaded and reloaded without resulting in duplicate data.
+"use strict";
+var fluid = fluid || require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+fluid.setLogging(true);
+
+var jqUnit = require("jqUnit");
+
+// We use just the request-handling bits of the kettle stack in our tests, but we include the whole thing to pick up the base grades
+require("../../node_modules/kettle");
+require("../../node_modules/kettle/lib/test/KettleTestUtils");
+
+require("./harness");
+require("../lib/sequence");
+
+fluid.registerNamespace("gpii.pouch.tests.reload");
+gpii.pouch.tests.reload.checkResponse = function (response, body) {
+    var jsonData = JSON.parse(body);
+    jqUnit.assertEquals("There should be three records...", 3, jsonData.doc_count);
+};
+
+fluid.defaults("gpii.pouch.tests.reload.caseHolder", {
+    gradeNames: ["fluid.test.testCaseHolder", "autoInit"],
+    mergePolicy: {
+        rawModules:    "noexpand",
+        sequenceStart: "noexpand"
+    },
+    moduleSource: {
+        funcName: "gpii.pouch.tests.addRequiredSequences",
+        args:     ["{that}.options.sequenceStart", "{that}.options.rawModules"]
+    },
+    sequenceStart: [
+        { // This sequence point is required because of a QUnit bug - it defers the start of sequence by 13ms "to avoid any current callbacks" in its words
+            func: "{testEnvironment}.events.constructServer.fire"
+        },
+        {
+            listener: "fluid.identity",
+            event:    "{testEnvironment}.events.onReady"
+        }
+    ],
+    // Our raw test cases, that will have `sequenceStart` prepended before they are run.
+    rawModules: [
+        {
+            tests: [
+                {
+                    name: "Testing initial pouch load...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{firstRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.reload.checkResponse",
+                            event:    "{firstRequest}.events.onComplete",
+                            args:     ["{firstRequest}.nativeResponse", "{arguments}.0"]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing second pouch load...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{secondRequest}.send"
+                        },
+                        {
+                            listener: "gpii.pouch.tests.reload.checkResponse",
+                            event:    "{secondRequest}.events.onComplete",
+                            args:     ["{firstRequest}.nativeResponse", "{arguments}.0"]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    components: {
+        firstRequest: {
+            type: "kettle.test.request.http",
+            options: {
+                path: "{testEnvironment}.options.testUrl",
+                port: "{testEnvironment}.options.port",
+                method: "GET"
+            }
+        },
+        secondRequest: {
+            type: "kettle.test.request.http",
+            options: {
+                path: "{testEnvironment}.options.testUrl",
+                port: "{testEnvironment}.options.port",
+                method: "GET"
+            }
+        }
+    }
+});
+
+fluid.defaults("gpii.pouch.tests.reload.environment", {
+    gradeNames: ["fluid.test.testEnvironment", "autoInit"],
+    port:       6792,
+    baseUrl:    "http://localhost:6792/",
+    testUrl:    "/sample/",
+    events: {
+        constructServer: null,
+        onReady: null
+    },
+    components: {
+        harness: {
+            type: "gpii.pouch.tests.harness",
+            createOnEvent: "constructServer",
+            options: {
+                port:       "{testEnvironment}.options.port",
+                baseUrl:    "{testEnvironment}.options.baseUrl",
+                listeners: {
+                    onReady: "{testEnvironment}.events.onReady.fire"
+                }
+            }
+        },
+        testCaseHolder: {
+            type: "gpii.pouch.tests.reload.caseHolder"
+        }
+    }
+});
+
+gpii.pouch.tests.reload.environment();

--- a/tests/js/reload-tests.js
+++ b/tests/js/reload-tests.js
@@ -1,4 +1,8 @@
 // Confirming that pouch can safely be loaded and reloaded without resulting in duplicate data.
+//
+// This test only works at the moment because we have enacted a workaround and added an `_id` variable for all records.
+//
+// See https://issues.gpii.net/browse/GPII-1239 for details.
 "use strict";
 var fluid = fluid || require("infusion");
 var gpii  = fluid.registerNamespace("gpii");

--- a/tests/lib/assembleurl.js
+++ b/tests/lib/assembleurl.js
@@ -1,0 +1,22 @@
+// An expander to put together a base URL and relative path.
+// TODO: Consider moving this to a stringTemplate based system instead.
+"use strict";
+var fluid = fluid || require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+
+fluid.registerNamespace("gpii.pouch.tests");
+gpii.pouch.tests.assembleUrl = function (baseUrl, path, that) {
+    var fullPath;
+    // We have to be careful of double slashes (or no slashes)
+    if (baseUrl[baseUrl.length - 1] === "/" && path[0] === "/") {
+        fullPath = baseUrl + path.substring(1);
+    }
+    else if (baseUrl[baseUrl.length - 1] !== "/" && path[0] !== "/") {
+        fullPath = baseUrl + "/" + path;
+    }
+    else {
+        fullPath = baseUrl + path;
+    }
+    return fullPath;
+};

--- a/tests/lib/assembleurl.js
+++ b/tests/lib/assembleurl.js
@@ -6,7 +6,7 @@ var gpii  = fluid.registerNamespace("gpii");
 
 
 fluid.registerNamespace("gpii.pouch.tests");
-gpii.pouch.tests.assembleUrl = function (baseUrl, path, that) {
+gpii.pouch.tests.assembleUrl = function (baseUrl, path) {
     var fullPath;
     // We have to be careful of double slashes (or no slashes)
     if (baseUrl[baseUrl.length - 1] === "/" && path[0] === "/") {

--- a/tests/lib/sequence.js
+++ b/tests/lib/sequence.js
@@ -1,0 +1,21 @@
+// Common function to prepend common sequences to all test modules in a testCaseHolder.
+"use strict";
+var fluid = fluid || require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+// Wire in a specified set of starting sequences to a set of tests.
+fluid.registerNamespace("gpii.pouch.tests");
+gpii.pouch.tests.addRequiredSequences = function (sequenceStart, rawTests) {
+    var completeTests = fluid.copy(rawTests);
+
+    for (var a = 0; a < completeTests.length; a++) {
+        var testSuite = completeTests[a];
+        for (var b = 0; b < testSuite.tests.length; b++) {
+            var tests = testSuite.tests[b];
+            var modifiedSequence = sequenceStart.concat(tests.sequence);
+            tests.sequence = modifiedSequence;
+        }
+    }
+
+    return completeTests;
+};


### PR DESCRIPTION
Because memdown now has a global cache you can only ever have one instance available at a time.  This results in data spilling over between test runs.  This pull request adds tests for this and workaround code that scrubs all database content when the component is destroyed.

See [GPII-1239](https://issues.gpii.net/browse/GPII-1239) for background.
