### PR TITLE
GPII-1259:  postinstall hook breaks any build that requires gpii-pouchdb as a dependency...

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "gpii-pouch",
   "version": "0.0.0",
   "private": true,
+  "repository": "https://github.com/GPII/gpii-pouchdb",
+  "license": "BSD-3-Clause",
   "scripts": {
     "test": "node tests/js/all-tests.js",
     "postinstall": "grunt dedupe-infusion"
@@ -10,6 +12,11 @@
     "express": "4.10.5",
     "express-pouchdb": "0.14.0",
     "gpii-express": "git://github.com/GPII/gpii-express#d2b57d7920270926a0fad77c81a39541a2a1a6e6",
+    "grunt": "~0.4.4",
+    "grunt-shell": "0.6.4",
+    "grunt-contrib-jshint": "~0.9.0",
+    "grunt-jsonlint": "1.0.4",
+    "grunt-gpii": "git://github.com/GPII/grunt-gpii.git#58ae055833f437a9e91baedb9f39a22c5fdd727f",
     "infusion": "git://github.com/fluid-project/infusion.git#df5f8cfabf815a4086b778e73125c3c952dda4ec",
     "memdown": "1.0.0",
     "pouchdb": "3.3.1",
@@ -17,11 +24,6 @@
     "when": "^3.7.3"
   },
   "devDependencies": {
-    "grunt": "~0.4.4",
-    "grunt-shell": "0.6.4",
-    "grunt-contrib-jshint": "~0.9.0",
-    "grunt-jsonlint": "1.0.4",
-    "grunt-gpii": "git://github.com/GPII/grunt-gpii.git#58ae055833f437a9e91baedb9f39a22c5fdd727f",
     "jqUnit": "git://github.com/fluid-project/node-jqUnit.git#e9bf72445bd343a4f3aabe3ba96a1087d3498612",
     "kettle": "git://github.com/fluid-project/kettle.git#e79bb81196df68c97eaa9f96c485a4321b69af75",
     "request": "2.51.0",


### PR DESCRIPTION
In working with gpii-pouchdb-lucene, I noticed that `npm install` now fails.  I tracked this down to the new `postinstall` hook for `grunt dedupe-infusion`.  For this to work as expected, grunt and our plugins must be moved to the main dependency settings.
