### PR TITLE
GPII-1275:  Update to use latest version of gpii.express and infusion.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,21 +11,21 @@
   "dependencies": {
     "express": "4.10.5",
     "express-pouchdb": "0.14.0",
-    "gpii-express": "git://github.com/GPII/gpii-express#d2b57d7920270926a0fad77c81a39541a2a1a6e6",
+    "gpii-express": "git://github.com/GPII/gpii-express#72850f74cd05229216467b3e9af3c7364f4beee5",
     "grunt": "~0.4.4",
     "grunt-shell": "0.6.4",
     "grunt-contrib-jshint": "~0.9.0",
     "grunt-jsonlint": "1.0.4",
     "grunt-gpii": "git://github.com/GPII/grunt-gpii.git#58ae055833f437a9e91baedb9f39a22c5fdd727f",
-    "infusion": "git://github.com/fluid-project/infusion.git#df5f8cfabf815a4086b778e73125c3c952dda4ec",
+    "infusion": "git://github.com/fluid-project/infusion.git#282f1a318718eed0b0ec060fb8b4ad254417fd7e",
     "memdown": "1.0.0",
     "pouchdb": "3.3.1",
     "underscore-node": "0.1.2",
     "when": "^3.7.3"
   },
   "devDependencies": {
-    "jqUnit": "git://github.com/fluid-project/node-jqUnit.git#e9bf72445bd343a4f3aabe3ba96a1087d3498612",
-    "kettle": "git://github.com/fluid-project/kettle.git#e79bb81196df68c97eaa9f96c485a4321b69af75",
+    "jqUnit":     "git://github.com/fluid-project/node-jqUnit.git#b7ef53aac1ca365bf23d35d255fae874faa88b70",
+    "kettle":     "git://github.com/amb26/kettle.git#33e2826e78315c6d29b13c8ba810f54fef29e8ac",
     "request": "2.51.0",
     "tough-cookie": "0.12.1"
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "express": "4.10.5",
     "express-pouchdb": "0.14.0",
-    "gpii-express": "git://github.com/GPII/gpii-express#46d71db841cb4831649201aab123d690628a9e15",
+    "gpii-express": "git://github.com/the-t-in-rtf/gpii-express#4750af51a1fbe886a260d89097e58c1c624ab4f7",
     "grunt": "~0.4.4",
     "grunt-shell": "0.6.4",
     "grunt-contrib-jshint": "~0.9.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "express": "4.10.5",
     "express-pouchdb": "0.14.0",
-    "gpii-express": "git://github.com/GPII/gpii-express#72850f74cd05229216467b3e9af3c7364f4beee5",
+    "gpii-express": "git://github.com/GPII/gpii-express#46d71db841cb4831649201aab123d690628a9e15",
     "grunt": "~0.4.4",
     "grunt-shell": "0.6.4",
     "grunt-contrib-jshint": "~0.9.0",

--- a/src/js/pouch.js
+++ b/src/js/pouch.js
@@ -76,7 +76,7 @@ gpii.pouch.init = function (that) {
     }
 };
 
-gpii.pouch.handler = function (that, req, res) {
+gpii.pouch.route = function (that, req, res) {
     that.expressPouchdb(req, res);
 };
 
@@ -162,11 +162,11 @@ fluid.defaults("gpii.pouch", {
         }
     },
     invokers: {
-        "handler": {
-            funcName: "gpii.pouch.handler",
+        route: {
+            funcName: "gpii.pouch.route",
             args:     ["{that}", "{arguments}.0", "{arguments}.1"]
         },
-        "cleanup": {
+        cleanup: {
             funcName: "gpii.pouch.cleanup",
             args:     ["{that}"]
         }

--- a/src/js/pouch.js
+++ b/src/js/pouch.js
@@ -76,8 +76,8 @@ gpii.pouch.init = function (that) {
     }
 };
 
-gpii.pouch.getHandler = function (that) {
-    return that.expressPouchdb;
+gpii.pouch.handler = function (that, req, res) {
+    that.expressPouchdb(req, res);
 };
 
 // Remove all data from each database between runs, otherwise we encounter problems with data leaking between tests.
@@ -162,9 +162,9 @@ fluid.defaults("gpii.pouch", {
         }
     },
     invokers: {
-        "getHandler": {
-            funcName: "gpii.pouch.getHandler",
-            args:     ["{that}"]
+        "handler": {
+            funcName: "gpii.pouch.handler",
+            args:     ["{that}", "{arguments}.0", "{arguments}.1"]
         },
         "cleanup": {
             funcName: "gpii.pouch.cleanup",

--- a/src/js/pouch.js
+++ b/src/js/pouch.js
@@ -76,7 +76,7 @@ gpii.pouch.init = function (that) {
     }
 };
 
-gpii.pouch.getRouter = function (that) {
+gpii.pouch.getHandler = function (that) {
     return that.expressPouchdb;
 };
 
@@ -135,7 +135,7 @@ gpii.pouch.transformRecord = function (record) {
 };
 
 fluid.defaults("gpii.pouch", {
-    gradeNames:       ["fluid.standardRelayComponent", "gpii.express.router", "autoInit"],
+    gradeNames:       ["fluid.modelComponent", "gpii.express.router"],
     config:           "{gpii.express}.options.config",
     method:           "use", // We have to support all HTTP methods, as does our underlying router.
     path:             "/",
@@ -162,8 +162,8 @@ fluid.defaults("gpii.pouch", {
         }
     },
     invokers: {
-        "getRouter": {
-            funcName: "gpii.pouch.getRouter",
+        "getHandler": {
+            funcName: "gpii.pouch.getHandler",
             args:     ["{that}"]
         },
         "cleanup": {

--- a/tests/js/basic-tests.js
+++ b/tests/js/basic-tests.js
@@ -6,7 +6,7 @@ fluid.setLogging(true);
 var gpii       = fluid.registerNamespace("gpii");
 var jqUnit     = fluid.require("jqUnit");
 
-require("../../node_modules/gpii-express/tests/js/test-helpers");
+require("../../node_modules/gpii-express/tests/js/lib/test-helpers");
 
 // We use just the request-handling bits of the kettle stack in our tests, but we include the whole thing to pick up the base grades
 require("../../node_modules/kettle");
@@ -50,7 +50,7 @@ gpii.pouch.tests.basic.checkResponse = function (response, body, expectedStatus,
 //    });
 
 fluid.defaults("gpii.pouch.tests.basic.caseHolder", {
-    gradeNames: ["fluid.test.testCaseHolder", "autoInit"],
+    gradeNames: ["fluid.test.testCaseHolder"],
     expected: {
         root:         { "express-pouchdb": "Welcome!" },
         massive:      { total_rows: 150 },

--- a/tests/js/harness.js
+++ b/tests/js/harness.js
@@ -14,7 +14,7 @@ var userDataFile    = path.resolve(__dirname, "../data/users.json");
 var massiveDataFile = path.resolve(__dirname, "../data/massive.json");
 
 fluid.defaults("gpii.pouch.tests.harness", {
-    gradeNames: ["fluid.eventedComponent", "autoInit"],
+    gradeNames: ["fluid.component"],
     port:       6789,
     baseUrl:    "http://localhost:6789/",
     events: {

--- a/tests/js/reload-tests.js
+++ b/tests/js/reload-tests.js
@@ -25,7 +25,7 @@ gpii.pouch.tests.reload.checkResponse = function (response, body) {
 };
 
 fluid.defaults("gpii.pouch.tests.reload.caseHolder", {
-    gradeNames: ["fluid.test.testCaseHolder", "autoInit"],
+    gradeNames: ["fluid.test.testCaseHolder"],
     mergePolicy: {
         rawModules:    "noexpand",
         sequenceStart: "noexpand"


### PR DESCRIPTION
See [GPII-1275](https://issues.gpii.net/browse/GPII-1275) for details.
