### PR TITLE
GPII-3068: (redux) Update express-pouchdb to use "uncaught exception-safe" Infusion.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,757 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@the-t-in-rtf/express-pouchdb": {
+            "version": "4.0.0-20180523-1217",
+            "resolved": "https://registry.npmjs.org/@the-t-in-rtf/express-pouchdb/-/express-pouchdb-4.0.0-20180523-1217.tgz",
+            "integrity": "sha512-6dweBpUVEbV0fQUE9quyO/o6GUJ1G93JVMMaIwXouyiDvWfut37ziqMoFa4Xooc3ArgNEcNhYmpTPjcFYre8Ig==",
+            "requires": {
+                "@the-t-in-rtf/pouchdb-all-dbs": "1.0.2",
+                "basic-auth": "2.0.0",
+                "body-parser": "1.16.1",
+                "compression": "1.6.2",
+                "cookie-parser": "1.4.3",
+                "denodeify": "1.2.1",
+                "express": "4.14.1",
+                "extend": "3.0.0",
+                "header-case-normalizer": "1.0.3",
+                "mkdirp": "0.5.0",
+                "multiparty": "4.1.3",
+                "on-finished": "2.3.0",
+                "pouchdb-auth": "4.0.0",
+                "pouchdb-collections": "6.4.1",
+                "pouchdb-fauxton": "0.0.6",
+                "pouchdb-find": "6.4.1",
+                "pouchdb-list": "4.0.0",
+                "pouchdb-promise": "6.4.1",
+                "pouchdb-replicator": "4.0.0",
+                "pouchdb-rewrite": "4.0.0",
+                "pouchdb-security": "4.0.0",
+                "pouchdb-show": "4.0.0",
+                "pouchdb-size": "4.0.0",
+                "pouchdb-update": "4.0.0",
+                "pouchdb-validation": "4.0.0",
+                "pouchdb-vhost": "4.0.0",
+                "pouchdb-wrappers": "4.0.0",
+                "raw-body": "2.2.0",
+                "sanitize-filename": "1.6.1",
+                "uuid": "3.0.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+                },
+                "body-parser": {
+                    "version": "1.16.1",
+                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.1.tgz",
+                    "integrity": "sha1-UVQNBFrfp6DGmVoBS7ax7ZuAIyk=",
+                    "requires": {
+                        "bytes": "2.4.0",
+                        "content-type": "1.0.4",
+                        "debug": "2.6.1",
+                        "depd": "1.1.2",
+                        "http-errors": "1.5.1",
+                        "iconv-lite": "0.4.15",
+                        "on-finished": "2.3.0",
+                        "qs": "6.2.1",
+                        "raw-body": "2.2.0",
+                        "type-is": "1.6.15"
+                    }
+                },
+                "bytes": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+                    "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+                },
+                "compression": {
+                    "version": "1.6.2",
+                    "resolved": "http://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
+                    "integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
+                    "requires": {
+                        "accepts": "1.3.4",
+                        "bytes": "2.3.0",
+                        "compressible": "2.0.13",
+                        "debug": "2.2.0",
+                        "on-headers": "1.0.1",
+                        "vary": "1.1.2"
+                    },
+                    "dependencies": {
+                        "bytes": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
+                            "integrity": "sha1-1baAoWW2IBc5rLYRVCqrwtjOsHA="
+                        },
+                        "debug": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                            "requires": {
+                                "ms": "0.7.1"
+                            }
+                        },
+                        "ms": {
+                            "version": "0.7.1",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                        }
+                    }
+                },
+                "couchdb-eval": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/couchdb-eval/-/couchdb-eval-4.0.0.tgz",
+                    "integrity": "sha512-hAbNT/U/cLMUrFZ9eJjYyjUhIXVfQXTAPxFt9hzycj0Ut45MSznsrvS4aZK46d6ckGn555xmH3XzHui9GLGOXQ==",
+                    "requires": {
+                        "extend": "3.0.0",
+                        "pouchdb-plugin-error": "4.0.0"
+                    }
+                },
+                "couchdb-objects": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/couchdb-objects/-/couchdb-objects-4.0.0.tgz",
+                    "integrity": "sha512-Gw1rdUDjOWqKl9HhlaSlQy3D6AFKGlCA7Q6qPXlKx2Q9qVjvhl6a4Dg90npNU3XUoo1bbSVIzcHvbX9JYfug8w==",
+                    "requires": {
+                        "extend": "3.0.0",
+                        "header-case-normalizer": "1.0.3",
+                        "is-empty": "1.2.0",
+                        "pouchdb-promise": "6.4.1",
+                        "random-uuid-v4": "0.0.6"
+                    }
+                },
+                "couchdb-render": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/couchdb-render/-/couchdb-render-4.0.0.tgz",
+                    "integrity": "sha512-W3e4vX04bcWc9vr0QCVYFAzL6OmkY4HfcKxjcjj3o8JZTG7x8Crtnc9hN0/Zo0PmKKohJAXalk16XHddJXrCjg==",
+                    "requires": {
+                        "couchdb-eval": "4.0.0",
+                        "couchdb-resp-completer": "4.0.0",
+                        "extend": "3.0.0",
+                        "is-empty": "1.2.0",
+                        "pouchdb-plugin-error": "4.0.0"
+                    }
+                },
+                "couchdb-resp-completer": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/couchdb-resp-completer/-/couchdb-resp-completer-4.0.0.tgz",
+                    "integrity": "sha512-mIL7A68ONhb8k43mpwN+pKr0ZnoEm1MHGux8mWN3SL7pl2J2Xk3Gf/kVkyY0PuHtEW+GVY7715PbiXdt7Hn35Q==",
+                    "requires": {
+                        "extend": "3.0.0",
+                        "is-empty": "1.2.0",
+                        "pouchdb-plugin-error": "4.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
+                    "integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
+                    "requires": {
+                        "ms": "0.7.2"
+                    }
+                },
+                "etag": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+                    "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+                },
+                "express": {
+                    "version": "4.14.1",
+                    "resolved": "https://registry.npmjs.org/express/-/express-4.14.1.tgz",
+                    "integrity": "sha1-ZGwjf3ZvFIwhIK/wc4F7nk1+DTM=",
+                    "requires": {
+                        "accepts": "1.3.4",
+                        "array-flatten": "1.1.1",
+                        "content-disposition": "0.5.2",
+                        "content-type": "1.0.4",
+                        "cookie": "0.3.1",
+                        "cookie-signature": "1.0.6",
+                        "debug": "2.2.0",
+                        "depd": "1.1.2",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "etag": "1.7.0",
+                        "finalhandler": "0.5.1",
+                        "fresh": "0.3.0",
+                        "merge-descriptors": "1.0.1",
+                        "methods": "1.1.2",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "path-to-regexp": "0.1.7",
+                        "proxy-addr": "1.1.5",
+                        "qs": "6.2.0",
+                        "range-parser": "1.2.0",
+                        "send": "0.14.2",
+                        "serve-static": "1.11.2",
+                        "type-is": "1.6.15",
+                        "utils-merge": "1.0.0",
+                        "vary": "1.1.2"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                            "requires": {
+                                "ms": "0.7.1"
+                            }
+                        },
+                        "ms": {
+                            "version": "0.7.1",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                        },
+                        "qs": {
+                            "version": "6.2.0",
+                            "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+                            "integrity": "sha1-O3hIwDwt7OaalSKw+ujEEm10Xzs="
+                        }
+                    }
+                },
+                "extend": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                    "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+                },
+                "finalhandler": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz",
+                    "integrity": "sha1-LEANjUUwk1vCMlScX6OF7Afeb80=",
+                    "requires": {
+                        "debug": "2.2.0",
+                        "escape-html": "1.0.3",
+                        "on-finished": "2.3.0",
+                        "statuses": "1.3.1",
+                        "unpipe": "1.0.0"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                            "requires": {
+                                "ms": "0.7.1"
+                            }
+                        },
+                        "ms": {
+                            "version": "0.7.1",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                        },
+                        "statuses": {
+                            "version": "1.3.1",
+                            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+                            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+                        }
+                    }
+                },
+                "fresh": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+                    "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+                },
+                "get-folder-size": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-1.0.1.tgz",
+                    "integrity": "sha1-gC+kIIQ03nEgUYKxWrfxNSCI5YA=",
+                    "requires": {
+                        "async": "1.5.2",
+                        "gar": "1.0.3"
+                    }
+                },
+                "http-errors": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+                    "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.0.2",
+                        "statuses": "1.4.0"
+                    }
+                },
+                "iconv-lite": {
+                    "version": "0.4.15",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+                    "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+                },
+                "ipaddr.js": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+                    "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+                },
+                "is-empty": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-1.2.0.tgz",
+                    "integrity": "sha1-3pu1snhzigWgsJpX4ftNSjQan2s="
+                },
+                "lie": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+                    "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+                    "requires": {
+                        "immediate": "3.0.6"
+                    }
+                },
+                "mime": {
+                    "version": "1.3.4",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                    "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+                },
+                "mkdirp": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                    "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+                },
+                "pouchdb-auth": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-auth/-/pouchdb-auth-4.0.0.tgz",
+                    "integrity": "sha512-wn3zjNmtU89sRH5x1alfdOA2VC0YHRnTlJjHFQFdA/9BNi5uozTQbtywsJH+l1vzcmeq0gAvaVsu8plmdIAprQ==",
+                    "requires": {
+                        "base64url": "1.0.6",
+                        "couchdb-calculate-session-id": "1.1.3",
+                        "crypto-lite": "0.1.0",
+                        "pouchdb-bulkdocs-wrapper": "4.0.0",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-promise": "6.4.1",
+                        "pouchdb-req-http-query": "4.0.0",
+                        "pouchdb-system-db": "4.0.0",
+                        "pouchdb-validation": "4.0.0",
+                        "pouchdb-wrappers": "4.0.0",
+                        "promise-nodify": "1.0.2",
+                        "secure-random": "1.1.1"
+                    }
+                },
+                "pouchdb-binary-utils": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-6.4.1.tgz",
+                    "integrity": "sha512-o9zi2Z3kaeAMPHc6R4EhEelHQOtTRztGotjUEd7tIzslWkuGgbIdpzRR//ii7amBmTdrA/BPH1+OWlHFuli+Cg==",
+                    "requires": {
+                        "buffer-from": "0.1.1"
+                    }
+                },
+                "pouchdb-bulkdocs-wrapper": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-bulkdocs-wrapper/-/pouchdb-bulkdocs-wrapper-4.0.0.tgz",
+                    "integrity": "sha512-Xn64OmSmM5bbwuT5o84vCyZ71DYLj65tcvbjEA037llbKA1j+QQQmbw0Xi0YS/pXpV5k6qzR43LE6fN3/7f7Ig==",
+                    "requires": {
+                        "pouchdb-promise": "6.4.1"
+                    }
+                },
+                "pouchdb-changeslike-wrapper": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-changeslike-wrapper/-/pouchdb-changeslike-wrapper-4.0.0.tgz",
+                    "integrity": "sha512-dNsS7WwH+Gn7RRdlq/GuRdmSOEZQgtHwFM6Y+Tiptk+BW5LIddikuGSzxX8RsibYNBzMjCtOtPKS6L+Jbe2zEg=="
+                },
+                "pouchdb-collate": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-6.4.1.tgz",
+                    "integrity": "sha512-8jh+vYNHHKTFWFnglj+ff1TGo/FhR8Dy3SgoIQ67M05yk1RRpUT2kwEMRec5YAhp4Y1d4uUpgdEvnbHdEKVYmg=="
+                },
+                "pouchdb-collections": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.4.1.tgz",
+                    "integrity": "sha512-jwLcs5B6hI8XFBf6nWH9v+sgB/9Jg5rfmoONL2GQ0DxtmhtlRwhz1yFLj3lWZ0oOkN8OPap3pdJAVlMH1Njgjg=="
+                },
+                "pouchdb-errors": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.4.1.tgz",
+                    "integrity": "sha512-tuEufCOnetXmTVYdK/TxsagMuicf+3V1b5D5UuGwqFAFEwuu8cB1dxxE6iPiI2hz/4CBA0dAEtCaFNccvSxt8Q==",
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "pouchdb-find": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-find/-/pouchdb-find-6.4.1.tgz",
+                    "integrity": "sha512-u8DGuPkDxOlN1p2J/2Gjxx3yJq01cQR1JPqJ/poY0JEJsjQh5EkSolf/XRUt0SVNGhrqrsV4tI4I0Yc8gInjFw==",
+                    "requires": {
+                        "pouchdb-abstract-mapreduce": "6.4.1",
+                        "pouchdb-collate": "6.4.1",
+                        "pouchdb-md5": "6.4.1",
+                        "pouchdb-promise": "6.4.1",
+                        "pouchdb-selector-core": "6.4.1",
+                        "pouchdb-utils": "6.4.1"
+                    }
+                },
+                "pouchdb-list": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-list/-/pouchdb-list-4.0.0.tgz",
+                    "integrity": "sha512-AVtOA/jPkj0LVClU2C7yiLwutnnEbqerJzs5s3+siffR4bBifUncF6+E/bquwipzv++Pl6l1J7wVBUtMQ6UJiA==",
+                    "requires": {
+                        "couchdb-objects": "4.0.0",
+                        "couchdb-render": "4.0.0",
+                        "extend": "3.0.0",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-promise": "6.4.1",
+                        "pouchdb-req-http-query": "4.0.0",
+                        "promise-nodify": "1.0.2"
+                    }
+                },
+                "pouchdb-md5": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-6.4.1.tgz",
+                    "integrity": "sha512-lhcCus885yQ7DYnLlHeV64uOR/KrhGolRMRwh2AMPU2EIWRROvj7/lehtEUaOmo/F+YeZFUpwscc5Mtxqr8log==",
+                    "requires": {
+                        "pouchdb-binary-utils": "6.4.1",
+                        "spark-md5": "3.0.0"
+                    }
+                },
+                "pouchdb-plugin-error": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-plugin-error/-/pouchdb-plugin-error-4.0.0.tgz",
+                    "integrity": "sha512-7fcQWAAEN0NbqrG1mKyahx03mVT4Gw8BIY5G7bLf0OomelXKMAPpzvF02uzKMSXyTjx+/fCP6Yq+gHNVVjL+aQ=="
+                },
+                "pouchdb-promise": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.4.1.tgz",
+                    "integrity": "sha512-HYyKqNVAjxnkcLjd37shFf8CjJlW+wpD24Oc3UOyF7iNT0KmnWncXL7Kz0evYgNl5C4ZB+oOC8OdQSN/9QEdOw==",
+                    "requires": {
+                        "lie": "3.1.1"
+                    }
+                },
+                "pouchdb-replicator": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-replicator/-/pouchdb-replicator-4.0.0.tgz",
+                    "integrity": "sha512-ZeRijwCtPl+juz8h34aGh4JA4rNXrLqyQRp+UQQYwmiJRGPthB1h3BgFDh3qB3tb8kur9fjxvRam0GDH4w8WGw==",
+                    "requires": {
+                        "equals": "1.0.5",
+                        "extend": "3.0.0",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-promise": "6.4.1",
+                        "pouchdb-system-db": "4.0.0",
+                        "pouchdb-validation": "4.0.0",
+                        "promise-nodify": "1.0.2",
+                        "random-uuid-v4": "0.0.6"
+                    }
+                },
+                "pouchdb-req-http-query": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-req-http-query/-/pouchdb-req-http-query-4.0.0.tgz",
+                    "integrity": "sha512-mOwY5WZCHcZJc57/reWaWSpLp3/VcFDultMYOo5/Ck9/oBwZCo0kF6nOQ1/vxozcIQaDbT/q81bQbvD2M0o5NQ==",
+                    "requires": {
+                        "extend": "3.0.0",
+                        "header-case-normalizer": "1.0.3",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-promise": "6.4.1",
+                        "xmlhttprequest-cookie": "0.9.6"
+                    }
+                },
+                "pouchdb-rewrite": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-rewrite/-/pouchdb-rewrite-4.0.0.tgz",
+                    "integrity": "sha512-TcQCbl3+v1BUWlQddQiBb0CuOlWwogGPc1ThOWRHKEHc11JdRPZAgy+/Uqg96B0cLtLoVPxQ/XwhrJt+e4bRAQ==",
+                    "requires": {
+                        "couchdb-objects": "4.0.0",
+                        "extend": "3.0.0",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-req-http-query": "4.0.0",
+                        "pouchdb-route": "4.0.0",
+                        "promise-nodify": "1.0.2"
+                    }
+                },
+                "pouchdb-route": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-route/-/pouchdb-route-4.0.0.tgz",
+                    "integrity": "sha512-NifHoKtkXp9w3tHO4AAOHVlrpb0T3tseADpG7y1peC0mydk8Y+NHPcXKizk3K0LS5PYBOccn6JNuy/q2fpZscQ==",
+                    "requires": {
+                        "extend": "3.0.0",
+                        "pouchdb-plugin-error": "4.0.0"
+                    }
+                },
+                "pouchdb-security": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-security/-/pouchdb-security-4.0.0.tgz",
+                    "integrity": "sha512-9BrgtJQjEhA7EIfKzArVNyXbVBw2b8Tx3YKWUvfNpiW32TiYkKI6kOUPQD60oywyOBUsxavzmJXZUtxxptoVSQ==",
+                    "requires": {
+                        "extend": "3.0.0",
+                        "pouchdb-bulkdocs-wrapper": "4.0.0",
+                        "pouchdb-changeslike-wrapper": "4.0.0",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-promise": "6.4.1",
+                        "pouchdb-req-http-query": "4.0.0",
+                        "pouchdb-wrappers": "4.0.0",
+                        "promise-nodify": "1.0.2"
+                    }
+                },
+                "pouchdb-show": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-show/-/pouchdb-show-4.0.0.tgz",
+                    "integrity": "sha512-EkXQ6OAlHvh+5rrrmLMqenTCUNea7Vy8p4a6p08UurZcQojrt5I1Tt/xvqzWzwDRFf85iklaCKvvIGOypPzURg==",
+                    "requires": {
+                        "couchdb-objects": "4.0.0",
+                        "couchdb-render": "4.0.0",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-promise": "6.4.1",
+                        "pouchdb-req-http-query": "4.0.0",
+                        "promise-nodify": "1.0.2"
+                    }
+                },
+                "pouchdb-size": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-size/-/pouchdb-size-4.0.0.tgz",
+                    "integrity": "sha512-za98LtvpY++vnnJ+pMz/Mng9MxQ3cWBvKGFrZp5GSF++V49gRzABJiaR3hfM3DDPgiO0vdD97YyIOJGSu2RfeQ==",
+                    "requires": {
+                        "bluebird": "3.5.1",
+                        "get-folder-size": "1.0.1",
+                        "pouchdb-wrappers": "4.0.0",
+                        "promise-nodify": "1.0.2"
+                    }
+                },
+                "pouchdb-system-db": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-system-db/-/pouchdb-system-db-4.0.0.tgz",
+                    "integrity": "sha512-2iT/MThEmnOOWjSTGfODtqIs7aUudXyAY7NU1FdtZQeXcL4ADDlBkaEM0D7aaWddCZae17tbIgRhhXEuwr8Ruw==",
+                    "requires": {
+                        "pouchdb-changeslike-wrapper": "4.0.0",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-security": "4.0.0",
+                        "pouchdb-wrappers": "4.0.0"
+                    }
+                },
+                "pouchdb-update": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-update/-/pouchdb-update-4.0.0.tgz",
+                    "integrity": "sha512-MaWgldOEZ60rMiaTv0yvsOeeCIwour737dXBAJ3yui6pIabfwNFxZiG90tldDCLgn3pekopyzls4hs+RimYglw==",
+                    "requires": {
+                        "couchdb-eval": "4.0.0",
+                        "couchdb-objects": "4.0.0",
+                        "couchdb-resp-completer": "4.0.0",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-promise": "6.4.1",
+                        "pouchdb-req-http-query": "4.0.0",
+                        "promise-nodify": "1.0.2"
+                    }
+                },
+                "pouchdb-utils": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.4.1.tgz",
+                    "integrity": "sha512-nlMgWYAoeZqw1WWtSbyJ40XwmR56zBNeS05A8b1AOC+mD2vanGPCflV8gTo1hew+ibwNzDDZb6SP54ryqi+CDw==",
+                    "requires": {
+                        "argsarray": "0.0.1",
+                        "clone-buffer": "1.0.0",
+                        "immediate": "3.0.6",
+                        "inherits": "2.0.3",
+                        "pouchdb-collections": "6.4.1",
+                        "pouchdb-errors": "6.4.1",
+                        "pouchdb-promise": "6.4.1",
+                        "uuid": "3.2.1"
+                    },
+                    "dependencies": {
+                        "uuid": {
+                            "version": "3.2.1",
+                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+                            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+                        }
+                    }
+                },
+                "pouchdb-validation": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-validation/-/pouchdb-validation-4.0.0.tgz",
+                    "integrity": "sha512-AeGaECzkGtuTYF60FJCqxvMNqWUKIpZpKYsmXa7jjDnXwio03pxuk+jmMW+a3ulN52oeoP7r/9wDIT84QPPq+w==",
+                    "requires": {
+                        "couchdb-eval": "4.0.0",
+                        "couchdb-objects": "4.0.0",
+                        "pouchdb-bulkdocs-wrapper": "4.0.0",
+                        "pouchdb-plugin-error": "4.0.0",
+                        "pouchdb-promise": "6.4.1",
+                        "pouchdb-wrappers": "4.0.0",
+                        "random-uuid-v4": "0.0.6"
+                    }
+                },
+                "pouchdb-vhost": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-vhost/-/pouchdb-vhost-4.0.0.tgz",
+                    "integrity": "sha512-PI3FQtDKv+/xO8S+Wioqfr/8yLDlsRi3yVdlwUAmyiRVH0t2iS2nGxG+w+b87bpE9zFwvcIasfNS3uYZwkVI0w==",
+                    "requires": {
+                        "pouchdb-route": "4.0.0",
+                        "promise-nodify": "1.0.2"
+                    }
+                },
+                "pouchdb-wrappers": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/pouchdb-wrappers/-/pouchdb-wrappers-4.0.0.tgz",
+                    "integrity": "sha512-wcMJJD6fUTpCSvYQw9YNK0jn4xIhJVYOWh/A79kdI6iaSzm24hf6ZAC/wpXanAlvv2QhGzZ8I7K0sR4NnKLEcA==",
+                    "requires": {
+                        "promise-nodify": "1.0.2"
+                    }
+                },
+                "proxy-addr": {
+                    "version": "1.1.5",
+                    "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+                    "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+                    "requires": {
+                        "forwarded": "0.1.2",
+                        "ipaddr.js": "1.4.0"
+                    }
+                },
+                "qs": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
+                    "integrity": "sha1-zgPF/wk1vB2daanxTL0Y5WjWdiU="
+                },
+                "random-uuid-v4": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/random-uuid-v4/-/random-uuid-v4-0.0.6.tgz",
+                    "integrity": "sha1-3F7beSat9HG1XXnL/Jg69bSXmwM="
+                },
+                "raw-body": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+                    "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
+                    "requires": {
+                        "bytes": "2.4.0",
+                        "iconv-lite": "0.4.15",
+                        "unpipe": "1.0.0"
+                    }
+                },
+                "send": {
+                    "version": "0.14.2",
+                    "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
+                    "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
+                    "requires": {
+                        "debug": "2.2.0",
+                        "depd": "1.1.2",
+                        "destroy": "1.0.4",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "etag": "1.7.0",
+                        "fresh": "0.3.0",
+                        "http-errors": "1.5.1",
+                        "mime": "1.3.4",
+                        "ms": "0.7.2",
+                        "on-finished": "2.3.0",
+                        "range-parser": "1.2.0",
+                        "statuses": "1.3.1"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.2.0",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                            "requires": {
+                                "ms": "0.7.1"
+                            },
+                            "dependencies": {
+                                "ms": {
+                                    "version": "0.7.1",
+                                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+                                }
+                            }
+                        },
+                        "statuses": {
+                            "version": "1.3.1",
+                            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+                            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+                        }
+                    }
+                },
+                "serve-static": {
+                    "version": "1.11.2",
+                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz",
+                    "integrity": "sha1-LPmIm9RDWjIMw2iVyapXvWYuasc=",
+                    "requires": {
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "parseurl": "1.3.2",
+                        "send": "0.14.2"
+                    }
+                },
+                "setprototypeof": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+                    "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
+                },
+                "utils-merge": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                    "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                    "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+                }
+            }
+        },
+        "@the-t-in-rtf/pouchdb-all-dbs": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@the-t-in-rtf/pouchdb-all-dbs/-/pouchdb-all-dbs-1.0.2.tgz",
+            "integrity": "sha512-4BcGEh3xIP71zHFuYslxhKniJYVRcEjMa19eEaATmRs08XezFAYaoWAwNDpBtqteKd12wRZyCjNc3ighvAB07g==",
+            "requires": {
+                "argsarray": "0.0.1",
+                "es3ify": "0.1.4",
+                "infusion": "3.0.0-dev.20180222T160835Z.6e1311a",
+                "inherits": "2.0.3",
+                "pouchdb-promise": "5.4.3",
+                "tiny-queue": "0.2.1"
+            },
+            "dependencies": {
+                "base62": {
+                    "version": "1.2.8",
+                    "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
+                    "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
+                },
+                "jstransform": {
+                    "version": "11.0.3",
+                    "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+                    "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+                    "requires": {
+                        "base62": "1.2.8",
+                        "commoner": "0.10.8",
+                        "esprima-fb": "15001.1.0-dev-harmony-fb",
+                        "object-assign": "2.1.1",
+                        "source-map": "0.4.4"
+                    }
+                },
+                "lie": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.4.tgz",
+                    "integrity": "sha1-vHrh6+fxyN45r9zU94kHa0ew9jQ=",
+                    "requires": {
+                        "es3ify": "0.2.2",
+                        "immediate": "3.0.6",
+                        "inline-process-browser": "1.0.0",
+                        "unreachable-branch-transform": "0.3.0"
+                    },
+                    "dependencies": {
+                        "es3ify": {
+                            "version": "0.2.2",
+                            "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.2.2.tgz",
+                            "integrity": "sha1-Xa4+ZQ5b42hLiAZlE9Uo0JJimGI=",
+                            "requires": {
+                                "esprima": "2.7.3",
+                                "jstransform": "11.0.3",
+                                "through": "2.3.8"
+                            }
+                        }
+                    }
+                },
+                "pouchdb-promise": {
+                    "version": "5.4.3",
+                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-5.4.3.tgz",
+                    "integrity": "sha1-Mx1nCxmJ1aA/JogRIU8n9UFQyys=",
+                    "requires": {
+                        "lie": "3.0.4"
+                    }
+                },
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "requires": {
+                        "amdefine": "1.0.1"
+                    }
+                }
+            }
+        },
         "JSV": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
@@ -32,6 +783,11 @@
                 "mime-types": "2.1.17",
                 "negotiator": "0.6.1"
             }
+        },
+        "acorn": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+            "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ=="
         },
         "acorn-jsx": {
             "version": "3.0.1",
@@ -87,8 +843,7 @@
         "amdefine": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-            "dev": true
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
         "ansi": {
             "version": "0.3.1",
@@ -227,6 +982,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "ast-types": {
+            "version": "0.9.6",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+            "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
         },
         "async-limiter": {
             "version": "1.0.0",
@@ -398,8 +1158,12 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base62": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+            "integrity": "sha1-e0F0wvlESXU7EcJlHAg9qEGnsIQ="
         },
         "base64-arraybuffer": {
             "version": "0.1.5",
@@ -412,6 +1176,23 @@
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
             "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
             "dev": true
+        },
+        "base64url": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
+            "integrity": "sha1-1k03XWinxkDZEuI1jRcNylu1RoE=",
+            "requires": {
+                "concat-stream": "1.4.10",
+                "meow": "2.0.0"
+            }
+        },
+        "basic-auth": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+            "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
         },
         "batch": {
             "version": "0.6.1",
@@ -498,8 +1279,7 @@
         "bluebird": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-            "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk=",
-            "dev": true
+            "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
         },
         "body-parser": {
             "version": "1.18.3",
@@ -594,7 +1374,6 @@
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-            "dev": true,
             "requires": {
                 "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
@@ -666,8 +1445,16 @@
         "camelcase": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-            "dev": true
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "camelcase-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+            "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
+            "requires": {
+                "camelcase": "1.2.1",
+                "map-obj": "1.0.1"
+            }
         },
         "caseless": {
             "version": "0.12.0",
@@ -976,8 +1763,23 @@
         "commander": {
             "version": "2.13.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-            "integrity": "sha1-aWS8pnaF33wfFDDFhPB9dZeIW5w=",
-            "dev": true
+            "integrity": "sha1-aWS8pnaF33wfFDDFhPB9dZeIW5w="
+        },
+        "commoner": {
+            "version": "0.10.8",
+            "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+            "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+            "requires": {
+                "commander": "2.13.0",
+                "detective": "4.7.1",
+                "glob": "5.0.15",
+                "graceful-fs": "4.1.11",
+                "iconv-lite": "0.4.19",
+                "mkdirp": "0.5.1",
+                "private": "0.1.8",
+                "q": "1.5.1",
+                "recast": "0.11.23"
+            }
         },
         "component-bind": {
             "version": "1.0.0",
@@ -997,17 +1799,30 @@
             "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
             "dev": true
         },
+        "compressible": {
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+            "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
+            "requires": {
+                "mime-db": "1.33.0"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.33.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+                    "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+                }
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
             "version": "1.4.10",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
             "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
-            "dev": true,
             "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "1.1.14",
@@ -1018,7 +1833,6 @@
                     "version": "1.1.14",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true,
                     "requires": {
                         "core-util-is": "1.0.2",
                         "inherits": "2.0.3",
@@ -1082,6 +1896,28 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
+        "couchdb-calculate-session-id": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/couchdb-calculate-session-id/-/couchdb-calculate-session-id-1.1.3.tgz",
+            "integrity": "sha512-7RJSTHf8cmeS07oB90LB1Kx7Yxbz/WQJOq9YEKpKJ6Eamca4ovXczMoZs6DlEu01j6DUgW6Z7zQpMxvYaOxskQ==",
+            "requires": {
+                "aproba": "1.2.0",
+                "base64url": "3.0.0",
+                "crypto-lite": "0.2.0"
+            },
+            "dependencies": {
+                "base64url": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.0.tgz",
+                    "integrity": "sha512-LIVmqIrIWuiqTvn4RzcrwCOuHo2DD6tKmKBPXXlr4p4n4l6BZBkwFTIa3zu1XkX5MbZgro4a6BvPi+n2Mns5Gg=="
+                },
+                "crypto-lite": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/crypto-lite/-/crypto-lite-0.2.0.tgz",
+                    "integrity": "sha1-OhTPYwOEYaXrhZRd54vwTeTar3M="
+                }
+            }
+        },
         "crc": {
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
@@ -1115,6 +1951,11 @@
                     }
                 }
             }
+        },
+        "crypto-lite": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/crypto-lite/-/crypto-lite-0.1.0.tgz",
+            "integrity": "sha1-l2ug9uu3PrWAZEvwjVPqhKxAxJA="
         },
         "currently-unhandled": {
             "version": "0.4.1",
@@ -1233,6 +2074,11 @@
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
         },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+        },
         "del": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -1265,6 +2111,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+        },
+        "denodeify": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+            "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE="
         },
         "depd": {
             "version": "1.1.2",
@@ -1300,6 +2151,15 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+        },
+        "detective": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+            "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+            "requires": {
+                "acorn": "5.5.3",
+                "defined": "1.0.0"
+            }
         },
         "doctrine": {
             "version": "2.1.0",
@@ -1506,6 +2366,14 @@
                 }
             }
         },
+        "equals": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/equals/-/equals-1.0.5.tgz",
+            "integrity": "sha1-ISBi3eXhpRDZVfE1mO/MamIbas4=",
+            "requires": {
+                "jkroso-type": "1.1.1"
+            }
+        },
         "errno": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
@@ -1521,6 +2389,23 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "0.2.1"
+            }
+        },
+        "es3ify": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.1.4.tgz",
+            "integrity": "sha1-rZ+l3xrjTz8x4SEbWBiy1RB439E=",
+            "requires": {
+                "esprima-fb": "3001.1.0-dev-harmony-fb",
+                "jstransform": "3.0.0",
+                "through": "2.3.8"
+            },
+            "dependencies": {
+                "esprima-fb": {
+                    "version": "3001.1.0-dev-harmony-fb",
+                    "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+                    "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE="
+                }
             }
         },
         "es5-ext": {
@@ -1822,11 +2707,20 @@
             "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
             "dev": true
         },
+        "esmangle-evaluator": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz",
+            "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
+        },
         "esprima": {
             "version": "2.7.3",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-            "dev": true
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        },
+        "esprima-fb": {
+            "version": "15001.1.0-dev-harmony-fb",
+            "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+            "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
         },
         "esquery": {
             "version": "1.0.0",
@@ -2129,6 +3023,24 @@
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
+        "falafel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+            "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
+            "requires": {
+                "acorn": "1.2.2",
+                "foreach": "2.0.5",
+                "isarray": "0.0.1",
+                "object-keys": "1.0.11"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+                    "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
+                }
+            }
+        },
         "fast-deep-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
@@ -2149,6 +3061,14 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "fd-slicer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "requires": {
+                "pend": "1.2.0"
+            }
         },
         "figures": {
             "version": "2.0.0",
@@ -2566,6 +3486,11 @@
             "resolved": "https://registry.npmjs.org/fluid-resolve/-/fluid-resolve-1.3.0.tgz",
             "integrity": "sha1-ODAp6xphlpgCvYVoTI4obm0sDf0="
         },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2625,6 +3550,11 @@
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
+        "gar": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.3.tgz",
+            "integrity": "sha512-zDpwk/l3HbhjVAvdxNUTJFzgXiNy0a7EmE/50XT38o1z+7NJbFhp+8CDsv1Qgy2adBAwUVYlMpIX2fZUbmlUJw=="
+        },
         "gauge": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
@@ -2656,8 +3586,7 @@
         "get-stdin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-            "dev": true
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
         },
         "get-stream": {
             "version": "3.0.0",
@@ -2707,7 +3636,6 @@
             "version": "5.0.15",
             "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
             "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-            "dev": true,
             "requires": {
                 "inflight": "1.0.6",
                 "inherits": "2.0.3",
@@ -4937,6 +5865,11 @@
                 "sntp": "2.1.0"
             }
         },
+        "header-case-normalizer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/header-case-normalizer/-/header-case-normalizer-1.0.3.tgz",
+            "integrity": "sha1-+x1MjQxhadyrT3x+IbGGpqIqwME="
+        },
         "hoek": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
@@ -5024,6 +5957,23 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "indent-string": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+            "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
+            "requires": {
+                "get-stdin": "4.0.1",
+                "minimist": "1.2.0",
+                "repeating": "1.1.3"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                }
+            }
+        },
         "indexof": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -5039,7 +5989,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "1.4.0",
                 "wrappy": "1.0.2"
@@ -5062,6 +6011,15 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+        },
+        "inline-process-browser": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz",
+            "integrity": "sha1-RqYbFT3TybFiSxoAYm7bT39BTyI=",
+            "requires": {
+                "falafel": "1.2.0",
+                "through2": "0.6.5"
+            }
         },
         "inquirer": {
             "version": "3.3.0",
@@ -5149,7 +6107,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-            "dev": true,
             "requires": {
                 "number-is-nan": "1.0.1"
             }
@@ -5323,8 +6280,7 @@
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-            "dev": true
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "isexe": {
             "version": "2.0.0",
@@ -5420,6 +6376,11 @@
                 "istanbul-lib-coverage": "1.2.0",
                 "semver": "5.3.0"
             }
+        },
+        "jkroso-type": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/jkroso-type/-/jkroso-type-1.1.1.tgz",
+            "integrity": "sha1-vEztbWxF/gdFKCuvyGqfjE/JzmE="
         },
         "js-tokens": {
             "version": "3.0.2",
@@ -5551,6 +6512,23 @@
                 "extsprintf": "1.3.0",
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
+            }
+        },
+        "jstransform": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-3.0.0.tgz",
+            "integrity": "sha1-olkats7o2XvzvoMNv6IxO4fNZAs=",
+            "requires": {
+                "base62": "0.1.1",
+                "esprima-fb": "3001.1.0-dev-harmony-fb",
+                "source-map": "0.1.31"
+            },
+            "dependencies": {
+                "esprima-fb": {
+                    "version": "3001.1.0-dev-harmony-fb",
+                    "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
+                    "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE="
+                }
             }
         },
         "kettle": {
@@ -6193,8 +7171,7 @@
         "map-obj": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-            "dev": true
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         },
         "math-clamp-x": {
             "version": "1.2.0",
@@ -6260,6 +7237,29 @@
                 "readable-stream": "1.0.34"
             }
         },
+        "meow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
+            "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
+            "requires": {
+                "camelcase-keys": "1.0.0",
+                "indent-string": "1.2.2",
+                "minimist": "1.2.0",
+                "object-assign": "1.0.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                },
+                "object-assign": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
+                    "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY="
+                }
+            }
+        },
         "merge-descriptors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -6303,7 +7303,6 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-            "dev": true,
             "requires": {
                 "brace-expansion": "1.1.8"
             }
@@ -6358,6 +7357,14 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "multiparty": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.1.3.tgz",
+            "integrity": "sha1-PEPH/LGJbhdGBDap3Qtu8WaOT5Q=",
+            "requires": {
+                "fd-slicer": "1.0.1"
+            }
         },
         "mustache": {
             "version": "2.3.0",
@@ -9301,6 +10308,11 @@
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
             "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
+        "object-assign": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+            "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+        },
         "object-component": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
@@ -9323,6 +10335,11 @@
                 "to-object-x": "1.5.0",
                 "to-property-key-x": "2.0.2"
             }
+        },
+        "object-keys": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
         },
         "on-finished": {
             "version": "2.3.0",
@@ -9492,8 +10509,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -9522,6 +10538,11 @@
                 "pify": "2.3.0",
                 "pinkie-promise": "2.0.1"
             }
+        },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
         },
         "performance-now": {
             "version": "2.1.0",
@@ -9788,6 +10809,210 @@
                 }
             }
         },
+        "pouchdb-abstract-mapreduce": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/pouchdb-abstract-mapreduce/-/pouchdb-abstract-mapreduce-6.4.1.tgz",
+            "integrity": "sha512-/AVLZo6Ax8IFbQblsy0Sd8fs4Io7X313TYmC8FKEYlUluCmbCw19+orF4MKsh5TZ5/E7EYjPpOORsWHH2gzKyA==",
+            "requires": {
+                "pouchdb-binary-utils": "6.4.1",
+                "pouchdb-collate": "6.4.1",
+                "pouchdb-collections": "6.4.1",
+                "pouchdb-mapreduce-utils": "6.4.1",
+                "pouchdb-md5": "6.4.1",
+                "pouchdb-promise": "6.4.1",
+                "pouchdb-utils": "6.4.1"
+            },
+            "dependencies": {
+                "lie": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+                    "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+                    "requires": {
+                        "immediate": "3.0.6"
+                    }
+                },
+                "pouchdb-binary-utils": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-6.4.1.tgz",
+                    "integrity": "sha512-o9zi2Z3kaeAMPHc6R4EhEelHQOtTRztGotjUEd7tIzslWkuGgbIdpzRR//ii7amBmTdrA/BPH1+OWlHFuli+Cg==",
+                    "requires": {
+                        "buffer-from": "0.1.1"
+                    }
+                },
+                "pouchdb-collate": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-6.4.1.tgz",
+                    "integrity": "sha512-8jh+vYNHHKTFWFnglj+ff1TGo/FhR8Dy3SgoIQ67M05yk1RRpUT2kwEMRec5YAhp4Y1d4uUpgdEvnbHdEKVYmg=="
+                },
+                "pouchdb-collections": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.4.1.tgz",
+                    "integrity": "sha512-jwLcs5B6hI8XFBf6nWH9v+sgB/9Jg5rfmoONL2GQ0DxtmhtlRwhz1yFLj3lWZ0oOkN8OPap3pdJAVlMH1Njgjg=="
+                },
+                "pouchdb-errors": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.4.1.tgz",
+                    "integrity": "sha512-tuEufCOnetXmTVYdK/TxsagMuicf+3V1b5D5UuGwqFAFEwuu8cB1dxxE6iPiI2hz/4CBA0dAEtCaFNccvSxt8Q==",
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "pouchdb-md5": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-6.4.1.tgz",
+                    "integrity": "sha512-lhcCus885yQ7DYnLlHeV64uOR/KrhGolRMRwh2AMPU2EIWRROvj7/lehtEUaOmo/F+YeZFUpwscc5Mtxqr8log==",
+                    "requires": {
+                        "pouchdb-binary-utils": "6.4.1",
+                        "spark-md5": "3.0.0"
+                    }
+                },
+                "pouchdb-promise": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.4.1.tgz",
+                    "integrity": "sha512-HYyKqNVAjxnkcLjd37shFf8CjJlW+wpD24Oc3UOyF7iNT0KmnWncXL7Kz0evYgNl5C4ZB+oOC8OdQSN/9QEdOw==",
+                    "requires": {
+                        "lie": "3.1.1"
+                    }
+                },
+                "pouchdb-utils": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.4.1.tgz",
+                    "integrity": "sha512-nlMgWYAoeZqw1WWtSbyJ40XwmR56zBNeS05A8b1AOC+mD2vanGPCflV8gTo1hew+ibwNzDDZb6SP54ryqi+CDw==",
+                    "requires": {
+                        "argsarray": "0.0.1",
+                        "clone-buffer": "1.0.0",
+                        "immediate": "3.0.6",
+                        "inherits": "2.0.3",
+                        "pouchdb-collections": "6.4.1",
+                        "pouchdb-errors": "6.4.1",
+                        "pouchdb-promise": "6.4.1",
+                        "uuid": "3.2.1"
+                    }
+                }
+            }
+        },
+        "pouchdb-fauxton": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/pouchdb-fauxton/-/pouchdb-fauxton-0.0.6.tgz",
+            "integrity": "sha1-/PriZaPWIekT69A17sM4pO+pKqE="
+        },
+        "pouchdb-mapreduce-utils": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/pouchdb-mapreduce-utils/-/pouchdb-mapreduce-utils-6.4.1.tgz",
+            "integrity": "sha512-KgOSUNRqSqoFzwl8XO2YXMtXChldLN+nLfuvLCLHmoMwNRZ1wY4n+xGdQnAf76GucRll+KRNAWX5gTj8Zq4s1g==",
+            "requires": {
+                "argsarray": "0.0.1",
+                "inherits": "2.0.3",
+                "pouchdb-collections": "6.4.1",
+                "pouchdb-utils": "6.4.1"
+            },
+            "dependencies": {
+                "lie": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+                    "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+                    "requires": {
+                        "immediate": "3.0.6"
+                    }
+                },
+                "pouchdb-collections": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.4.1.tgz",
+                    "integrity": "sha512-jwLcs5B6hI8XFBf6nWH9v+sgB/9Jg5rfmoONL2GQ0DxtmhtlRwhz1yFLj3lWZ0oOkN8OPap3pdJAVlMH1Njgjg=="
+                },
+                "pouchdb-errors": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.4.1.tgz",
+                    "integrity": "sha512-tuEufCOnetXmTVYdK/TxsagMuicf+3V1b5D5UuGwqFAFEwuu8cB1dxxE6iPiI2hz/4CBA0dAEtCaFNccvSxt8Q==",
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "pouchdb-promise": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.4.1.tgz",
+                    "integrity": "sha512-HYyKqNVAjxnkcLjd37shFf8CjJlW+wpD24Oc3UOyF7iNT0KmnWncXL7Kz0evYgNl5C4ZB+oOC8OdQSN/9QEdOw==",
+                    "requires": {
+                        "lie": "3.1.1"
+                    }
+                },
+                "pouchdb-utils": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.4.1.tgz",
+                    "integrity": "sha512-nlMgWYAoeZqw1WWtSbyJ40XwmR56zBNeS05A8b1AOC+mD2vanGPCflV8gTo1hew+ibwNzDDZb6SP54ryqi+CDw==",
+                    "requires": {
+                        "argsarray": "0.0.1",
+                        "clone-buffer": "1.0.0",
+                        "immediate": "3.0.6",
+                        "inherits": "2.0.3",
+                        "pouchdb-collections": "6.4.1",
+                        "pouchdb-errors": "6.4.1",
+                        "pouchdb-promise": "6.4.1",
+                        "uuid": "3.2.1"
+                    }
+                }
+            }
+        },
+        "pouchdb-selector-core": {
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/pouchdb-selector-core/-/pouchdb-selector-core-6.4.1.tgz",
+            "integrity": "sha512-blrYDhvErVPmgeZsAfEJfkbQd+7Z5W614MVFQycQ07o2JnfkOw0uiPLb3rz/uUgeO0qfd+FzmIocL7/jpKoGDA==",
+            "requires": {
+                "pouchdb-collate": "6.4.1",
+                "pouchdb-utils": "6.4.1"
+            },
+            "dependencies": {
+                "lie": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+                    "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+                    "requires": {
+                        "immediate": "3.0.6"
+                    }
+                },
+                "pouchdb-collate": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-6.4.1.tgz",
+                    "integrity": "sha512-8jh+vYNHHKTFWFnglj+ff1TGo/FhR8Dy3SgoIQ67M05yk1RRpUT2kwEMRec5YAhp4Y1d4uUpgdEvnbHdEKVYmg=="
+                },
+                "pouchdb-collections": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-6.4.1.tgz",
+                    "integrity": "sha512-jwLcs5B6hI8XFBf6nWH9v+sgB/9Jg5rfmoONL2GQ0DxtmhtlRwhz1yFLj3lWZ0oOkN8OPap3pdJAVlMH1Njgjg=="
+                },
+                "pouchdb-errors": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-6.4.1.tgz",
+                    "integrity": "sha512-tuEufCOnetXmTVYdK/TxsagMuicf+3V1b5D5UuGwqFAFEwuu8cB1dxxE6iPiI2hz/4CBA0dAEtCaFNccvSxt8Q==",
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "pouchdb-promise": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.4.1.tgz",
+                    "integrity": "sha512-HYyKqNVAjxnkcLjd37shFf8CjJlW+wpD24Oc3UOyF7iNT0KmnWncXL7Kz0evYgNl5C4ZB+oOC8OdQSN/9QEdOw==",
+                    "requires": {
+                        "lie": "3.1.1"
+                    }
+                },
+                "pouchdb-utils": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-6.4.1.tgz",
+                    "integrity": "sha512-nlMgWYAoeZqw1WWtSbyJ40XwmR56zBNeS05A8b1AOC+mD2vanGPCflV8gTo1hew+ibwNzDDZb6SP54ryqi+CDw==",
+                    "requires": {
+                        "argsarray": "0.0.1",
+                        "clone-buffer": "1.0.0",
+                        "immediate": "3.0.6",
+                        "inherits": "2.0.3",
+                        "pouchdb-collections": "6.4.1",
+                        "pouchdb-errors": "6.4.1",
+                        "pouchdb-promise": "6.4.1",
+                        "uuid": "3.2.1"
+                    }
+                }
+            }
+        },
         "prebuild": {
             "version": "7.6.0",
             "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-7.6.0.tgz",
@@ -10047,6 +11272,11 @@
             "integrity": "sha1-xDjKLKM+OSdnHbSracDlL5NqTw8=",
             "dev": true
         },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+        },
         "process-nextick-args": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -10057,6 +11287,11 @@
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
             "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
             "dev": true
+        },
+        "promise-nodify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/promise-nodify/-/promise-nodify-1.0.2.tgz",
+            "integrity": "sha1-DQ+xQ8M0ALAGG0flgSV1VwR9TFo="
         },
         "property-is-enumerable-x": {
             "version": "1.1.0",
@@ -10100,6 +11335,11 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
         "qs": {
             "version": "6.5.1",
@@ -10170,7 +11410,6 @@
             "version": "1.0.34",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-            "dev": true,
             "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -10203,6 +11442,29 @@
                     "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
                     "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
                     "dev": true
+                }
+            }
+        },
+        "recast": {
+            "version": "0.11.23",
+            "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+            "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+            "requires": {
+                "ast-types": "0.9.6",
+                "esprima": "3.1.3",
+                "private": "0.1.8",
+                "source-map": "0.5.7"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
                 }
             }
         },
@@ -10253,6 +11515,14 @@
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
+        },
+        "repeating": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+            "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+            "requires": {
+                "is-finite": "1.0.2"
+            }
         },
         "replace-comments-x": {
             "version": "2.0.0",
@@ -10413,6 +11683,19 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "sanitize-filename": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+            "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+            "requires": {
+                "truncate-utf8-bytes": "1.0.2"
+            }
+        },
+        "secure-random": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.1.tgz",
+            "integrity": "sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo="
         },
         "semver": {
             "version": "5.3.0",
@@ -10684,6 +11967,14 @@
                 }
             }
         },
+        "source-map": {
+            "version": "0.1.31",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+            "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
+            "requires": {
+                "amdefine": "1.0.1"
+            }
+        },
         "source-map-support": {
             "version": "0.2.10",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
@@ -10703,6 +11994,11 @@
                     }
                 }
             }
+        },
+        "spark-md5": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.0.tgz",
+            "integrity": "sha1-NyIifFTi+vJLHcbZM8wUTm9xv+8="
         },
         "spawn-args": {
             "version": "0.2.0",
@@ -11275,18 +12571,21 @@
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
             "version": "0.6.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-            "dev": true,
             "requires": {
                 "readable-stream": "1.0.34",
                 "xtend": "4.0.1"
             }
+        },
+        "tiny-queue": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/tiny-queue/-/tiny-queue-0.2.1.tgz",
+            "integrity": "sha1-JaZ/LG4lOyypQZd7XvdELvl6YEY="
         },
         "tmp": {
             "version": "0.0.33",
@@ -11483,6 +12782,14 @@
                 "trim-right-x": "3.0.0"
             }
         },
+        "truncate-utf8-bytes": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+            "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+            "requires": {
+                "utf8-byte-length": "1.0.4"
+            }
+        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -11518,8 +12825,7 @@
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-            "dev": true
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "uglify-js": {
             "version": "2.8.29",
@@ -11590,6 +12896,44 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+        },
+        "unreachable-branch-transform": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
+            "integrity": "sha1-2ZzExudG0mSSiEW2EdtUsPNHTKo=",
+            "requires": {
+                "esmangle-evaluator": "1.0.1",
+                "recast": "0.10.43",
+                "through2": "0.6.5"
+            },
+            "dependencies": {
+                "ast-types": {
+                    "version": "0.8.15",
+                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+                    "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI="
+                },
+                "esprima-fb": {
+                    "version": "15001.1001.0-dev-harmony-fb",
+                    "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                    "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+                },
+                "recast": {
+                    "version": "0.10.43",
+                    "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+                    "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
+                    "requires": {
+                        "ast-types": "0.8.15",
+                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+                        "private": "0.1.8",
+                        "source-map": "0.5.7"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+                }
+            }
         },
         "unzipper": {
             "version": "0.8.14",
@@ -11666,6 +13010,11 @@
             "requires": {
                 "os-homedir": "1.0.2"
             }
+        },
+        "utf8-byte-length": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+            "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -11840,6 +13189,19 @@
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
             "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
             "dev": true
+        },
+        "xmlhttprequest": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+            "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+        },
+        "xmlhttprequest-cookie": {
+            "version": "0.9.6",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-cookie/-/xmlhttprequest-cookie-0.9.6.tgz",
+            "integrity": "sha512-HjGd9DEXQtuvsKFIVXuVdo7MJO7cAL2LdimzThxyLcIfkp6waMoZl22nbnuI2/GkXCTtF0W1xzBli8G+yEyi1g==",
+            "requires": {
+                "xmlhttprequest": "1.8.0"
+            }
         },
         "xmlhttprequest-ssl": {
             "version": "1.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "gpii-pouchdb",
-    "version": "1.0.12",
+    "version": "1.0.12-dev.20180523T102341Z.d742612",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,11 +33,6 @@
                 "negotiator": "0.6.1"
             }
         },
-        "acorn": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-            "integrity": "sha1-dEbTlFnFT7SagObuZHgUm5QOyCI="
-        },
         "acorn-jsx": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
@@ -92,7 +87,8 @@
         "amdefine": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
         },
         "ansi": {
             "version": "0.3.1",
@@ -231,16 +227,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "ast-types": {
-            "version": "0.9.6",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-            "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
-        },
-        "async": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
         },
         "async-limiter": {
             "version": "1.0.0",
@@ -412,12 +398,8 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-        },
-        "base62": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
-            "integrity": "sha1-e0F0wvlESXU7EcJlHAg9qEGnsIQ="
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
         },
         "base64-arraybuffer": {
             "version": "0.1.5",
@@ -430,23 +412,6 @@
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
             "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
             "dev": true
-        },
-        "base64url": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/base64url/-/base64url-1.0.6.tgz",
-            "integrity": "sha1-1k03XWinxkDZEuI1jRcNylu1RoE=",
-            "requires": {
-                "concat-stream": "1.4.10",
-                "meow": "2.0.0"
-            }
-        },
-        "basic-auth": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
-            "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
-            "requires": {
-                "safe-buffer": "5.1.1"
-            }
         },
         "batch": {
             "version": "0.6.1",
@@ -533,7 +498,8 @@
         "bluebird": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-            "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
+            "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk=",
+            "dev": true
         },
         "body-parser": {
             "version": "1.18.3",
@@ -628,6 +594,7 @@
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true,
             "requires": {
                 "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
@@ -699,16 +666,8 @@
         "camelcase": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-        },
-        "camelcase-keys": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-            "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
-            "requires": {
-                "camelcase": "1.2.1",
-                "map-obj": "1.0.1"
-            }
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "dev": true
         },
         "caseless": {
             "version": "0.12.0",
@@ -1017,23 +976,8 @@
         "commander": {
             "version": "2.13.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-            "integrity": "sha1-aWS8pnaF33wfFDDFhPB9dZeIW5w="
-        },
-        "commoner": {
-            "version": "0.10.8",
-            "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-            "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-            "requires": {
-                "commander": "2.13.0",
-                "detective": "4.7.1",
-                "glob": "5.0.15",
-                "graceful-fs": "4.1.11",
-                "iconv-lite": "0.4.19",
-                "mkdirp": "0.5.1",
-                "private": "0.1.8",
-                "q": "1.5.1",
-                "recast": "0.11.23"
-            }
+            "integrity": "sha1-aWS8pnaF33wfFDDFhPB9dZeIW5w=",
+            "dev": true
         },
         "component-bind": {
             "version": "1.0.0",
@@ -1053,37 +997,17 @@
             "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
             "dev": true
         },
-        "compressible": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
-            "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
-            "requires": {
-                "mime-db": "1.30.0"
-            }
-        },
-        "compression": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
-            "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
-            "requires": {
-                "accepts": "1.3.4",
-                "bytes": "3.0.0",
-                "compressible": "2.0.12",
-                "debug": "2.6.9",
-                "on-headers": "1.0.1",
-                "safe-buffer": "5.1.1",
-                "vary": "1.1.2"
-            }
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "concat-stream": {
             "version": "1.4.10",
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
             "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
+            "dev": true,
             "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "1.1.14",
@@ -1094,6 +1018,7 @@
                     "version": "1.1.14",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "dev": true,
                     "requires": {
                         "core-util-is": "1.0.2",
                         "inherits": "2.0.3",
@@ -1157,121 +1082,6 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
-        "couchdb-calculate-session-id": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/couchdb-calculate-session-id/-/couchdb-calculate-session-id-1.1.2.tgz",
-            "integrity": "sha1-NkoVao23thIDleo+IQ8k7wwlWhw=",
-            "requires": {
-                "aproba": "1.2.0",
-                "base64url": "2.0.0",
-                "crypto-lite": "0.2.0"
-            },
-            "dependencies": {
-                "base64url": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-                    "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-                },
-                "crypto-lite": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/crypto-lite/-/crypto-lite-0.2.0.tgz",
-                    "integrity": "sha1-OhTPYwOEYaXrhZRd54vwTeTar3M="
-                }
-            }
-        },
-        "couchdb-eval": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/couchdb-eval/-/couchdb-eval-1.0.6.tgz",
-            "integrity": "sha1-A85qFNpijJ+XtgJpBTv7/+nLNTk=",
-            "requires": {
-                "extend": "1.3.0",
-                "pouchdb-plugin-error": "1.0.1"
-            },
-            "dependencies": {
-                "extend": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-                    "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-                }
-            }
-        },
-        "couchdb-objects": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/couchdb-objects/-/couchdb-objects-1.0.7.tgz",
-            "integrity": "sha1-Cn5AZ96eCMocV244IhQtKqVYBNg=",
-            "requires": {
-                "extend": "1.3.0",
-                "header-case-normalizer": "1.0.3",
-                "is-empty": "0.0.1",
-                "pouchdb-promise": "0.0.0",
-                "random-uuid-v4": "0.0.4"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz",
-                    "integrity": "sha1-WYXsI8tv8aWDTMZEezxe8BD9Mho="
-                },
-                "extend": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-                    "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-                },
-                "lie": {
-                    "version": "2.7.7",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-2.7.7.tgz",
-                    "integrity": "sha1-fPlZvtSJWbBi8Drka7vzqsMCark=",
-                    "requires": {
-                        "immediate": "3.0.6"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-0.0.0.tgz",
-                    "integrity": "sha1-PAFOYndm2UW+PycOB5p9tNLRmCc=",
-                    "requires": {
-                        "bluebird": "1.2.4",
-                        "lie": "2.7.7"
-                    }
-                }
-            }
-        },
-        "couchdb-render": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/couchdb-render/-/couchdb-render-1.0.1.tgz",
-            "integrity": "sha1-iS5aQEDb3A0HuODKEsD1erG7EC8=",
-            "requires": {
-                "couchdb-eval": "1.0.6",
-                "couchdb-resp-completer": "1.0.3",
-                "extend": "1.3.0",
-                "is-empty": "0.0.1",
-                "pouchdb-plugin-error": "1.0.1"
-            },
-            "dependencies": {
-                "extend": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-                    "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-                }
-            }
-        },
-        "couchdb-resp-completer": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/couchdb-resp-completer/-/couchdb-resp-completer-1.0.3.tgz",
-            "integrity": "sha1-qksMAr8JBv33Nn+/i96OCsUy0hM=",
-            "requires": {
-                "extend": "1.3.0",
-                "is-empty": "0.0.1",
-                "pouchdb-plugin-error": "1.0.1"
-            },
-            "dependencies": {
-                "extend": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-                    "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-                }
-            }
-        },
         "crc": {
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
@@ -1305,11 +1115,6 @@
                     }
                 }
             }
-        },
-        "crypto-lite": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/crypto-lite/-/crypto-lite-0.1.0.tgz",
-            "integrity": "sha1-l2ug9uu3PrWAZEvwjVPqhKxAxJA="
         },
         "currently-unhandled": {
             "version": "0.4.1",
@@ -1428,11 +1233,6 @@
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
             "dev": true
         },
-        "defined": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-        },
         "del": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -1500,15 +1300,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-        },
-        "detective": {
-            "version": "4.7.1",
-            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-            "integrity": "sha1-DspzFDOEQv67bWXaVMELscgrJG4=",
-            "requires": {
-                "acorn": "5.3.0",
-                "defined": "1.0.0"
-            }
         },
         "doctrine": {
             "version": "2.1.0",
@@ -1715,14 +1506,6 @@
                 }
             }
         },
-        "equals": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/equals/-/equals-1.0.5.tgz",
-            "integrity": "sha1-ISBi3eXhpRDZVfE1mO/MamIbas4=",
-            "requires": {
-                "jkroso-type": "1.1.1"
-            }
-        },
         "errno": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
@@ -1738,16 +1521,6 @@
             "dev": true,
             "requires": {
                 "is-arrayish": "0.2.1"
-            }
-        },
-        "es3ify": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.1.4.tgz",
-            "integrity": "sha1-rZ+l3xrjTz8x4SEbWBiy1RB439E=",
-            "requires": {
-                "esprima-fb": "3001.1.0-dev-harmony-fb",
-                "jstransform": "3.0.0",
-                "through": "2.3.8"
             }
         },
         "es5-ext": {
@@ -2049,21 +1822,11 @@
             "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
             "dev": true
         },
-        "esmangle-evaluator": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz",
-            "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
-        },
         "esprima": {
             "version": "2.7.3",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
             "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
             "dev": true
-        },
-        "esprima-fb": {
-            "version": "3001.1.0-dev-harmony-fb",
-            "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz",
-            "integrity": "sha1-t303q8046gt3Qmu4vCkizmtCZBE="
         },
         "esquery": {
             "version": "1.0.0",
@@ -2329,55 +2092,6 @@
                 }
             }
         },
-        "express-pouchdb": {
-            "version": "git://github.com/the-t-in-rtf/express-pouchdb.git#299582cd5bbe33e4057135413c34b72c2c8a7167",
-            "requires": {
-                "basic-auth": "2.0.0",
-                "bluebird": "3.5.1",
-                "body-parser": "1.18.2",
-                "compression": "1.7.1",
-                "cookie-parser": "1.4.3",
-                "extend": "3.0.1",
-                "header-case-normalizer": "1.0.3",
-                "mkdirp": "0.5.1",
-                "multiparty": "4.1.3",
-                "node-uuid": "1.4.8",
-                "on-finished": "2.3.0",
-                "pouchdb-all-dbs": "git://github.com/the-t-in-rtf/pouchdb-all-dbs.git#010173f4afa7b752787885ee8606eda4c1f047bb",
-                "pouchdb-auth": "2.1.1",
-                "pouchdb-find": "0.10.3",
-                "pouchdb-list": "1.1.0",
-                "pouchdb-replicator": "2.1.3",
-                "pouchdb-rewrite": "1.0.7",
-                "pouchdb-security": "1.2.6",
-                "pouchdb-show": "1.0.8",
-                "pouchdb-size": "1.2.2",
-                "pouchdb-update": "1.0.8",
-                "pouchdb-validation": "1.2.1",
-                "pouchdb-vhost": "1.0.2",
-                "pouchdb-wrappers": "1.3.6",
-                "raw-body": "2.3.2"
-            },
-            "dependencies": {
-                "body-parser": {
-                    "version": "1.18.2",
-                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-                    "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-                    "requires": {
-                        "bytes": "3.0.0",
-                        "content-type": "1.0.4",
-                        "debug": "2.6.9",
-                        "depd": "1.1.2",
-                        "http-errors": "1.6.2",
-                        "iconv-lite": "0.4.19",
-                        "on-finished": "2.3.0",
-                        "qs": "6.5.1",
-                        "raw-body": "2.3.2",
-                        "type-is": "1.6.15"
-                    }
-                }
-            }
-        },
         "express-session": {
             "version": "1.15.6",
             "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",
@@ -2415,24 +2129,6 @@
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
-        "falafel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-            "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
-            "requires": {
-                "acorn": "1.2.2",
-                "foreach": "2.0.5",
-                "isarray": "0.0.1",
-                "object-keys": "1.0.11"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "1.2.2",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-                    "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
-                }
-            }
-        },
         "fast-deep-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
@@ -2453,14 +2149,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
-        },
-        "fd-slicer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-            "requires": {
-                "pend": "1.2.0"
-            }
         },
         "figures": {
             "version": "2.0.0",
@@ -2878,11 +2566,6 @@
             "resolved": "https://registry.npmjs.org/fluid-resolve/-/fluid-resolve-1.3.0.tgz",
             "integrity": "sha1-ODAp6xphlpgCvYVoTI4obm0sDf0="
         },
-        "foreach": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-        },
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2970,26 +2653,11 @@
                 "is-property": "1.0.2"
             }
         },
-        "get-folder-size": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-0.1.1.tgz",
-            "integrity": "sha1-0bhMUQC/lqfFE4DqPOBAAiEIqKA=",
-            "requires": {
-                "async": "0.9.2",
-                "minimist": "0.1.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.1.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
-                    "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
-                }
-            }
-        },
         "get-stdin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "dev": true
         },
         "get-stream": {
             "version": "3.0.0",
@@ -3039,6 +2707,7 @@
             "version": "5.0.15",
             "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
             "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+            "dev": true,
             "requires": {
                 "inflight": "1.0.6",
                 "inherits": "2.0.3",
@@ -3181,6 +2850,7 @@
                 "istanbul-lib-instrument": "1.9.2",
                 "mkdirp": "0.5.1",
                 "node-jqunit": "1.1.8",
+                "nyc": "11.4.1",
                 "rimraf": "2.6.2",
                 "testem": "2.0.0"
             },
@@ -3243,6 +2913,1600 @@
                         "console-control-strings": "1.1.0",
                         "gauge": "2.7.4",
                         "set-blocking": "2.0.0"
+                    }
+                },
+                "nyc": {
+                    "version": "11.4.1",
+                    "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
+                    "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+                    "dev": true,
+                    "requires": {
+                        "archy": "1.0.0",
+                        "arrify": "1.0.1",
+                        "caching-transform": "1.0.1",
+                        "convert-source-map": "1.5.1",
+                        "debug-log": "1.0.1",
+                        "default-require-extensions": "1.0.0",
+                        "find-cache-dir": "0.1.1",
+                        "find-up": "2.1.0",
+                        "foreground-child": "1.5.6",
+                        "glob": "7.1.2",
+                        "istanbul-lib-coverage": "1.1.1",
+                        "istanbul-lib-hook": "1.1.0",
+                        "istanbul-lib-instrument": "1.9.1",
+                        "istanbul-lib-report": "1.1.2",
+                        "istanbul-lib-source-maps": "1.2.2",
+                        "istanbul-reports": "1.1.3",
+                        "md5-hex": "1.3.0",
+                        "merge-source-map": "1.0.4",
+                        "micromatch": "2.3.11",
+                        "mkdirp": "0.5.1",
+                        "resolve-from": "2.0.0",
+                        "rimraf": "2.6.2",
+                        "signal-exit": "3.0.2",
+                        "spawn-wrap": "1.4.2",
+                        "test-exclude": "4.1.1",
+                        "yargs": "10.0.3",
+                        "yargs-parser": "8.0.0"
+                    },
+                    "dependencies": {
+                        "align-text": {
+                            "version": "0.1.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.6.1"
+                            }
+                        },
+                        "amdefine": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ansi-styles": {
+                            "version": "2.2.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "append-transform": {
+                            "version": "0.4.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "default-require-extensions": "1.0.0"
+                            }
+                        },
+                        "archy": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "arr-diff": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "arr-flatten": "1.1.0"
+                            }
+                        },
+                        "arr-flatten": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "array-unique": {
+                            "version": "0.2.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "arrify": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "async": {
+                            "version": "1.5.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "babel-code-frame": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "chalk": "1.1.3",
+                                "esutils": "2.0.2",
+                                "js-tokens": "3.0.2"
+                            }
+                        },
+                        "babel-generator": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "babel-messages": "6.23.0",
+                                "babel-runtime": "6.26.0",
+                                "babel-types": "6.26.0",
+                                "detect-indent": "4.0.0",
+                                "jsesc": "1.3.0",
+                                "lodash": "4.17.4",
+                                "source-map": "0.5.7",
+                                "trim-right": "1.0.1"
+                            }
+                        },
+                        "babel-messages": {
+                            "version": "6.23.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "babel-runtime": "6.26.0"
+                            }
+                        },
+                        "babel-runtime": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "core-js": "2.5.3",
+                                "regenerator-runtime": "0.11.1"
+                            }
+                        },
+                        "babel-template": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "babel-runtime": "6.26.0",
+                                "babel-traverse": "6.26.0",
+                                "babel-types": "6.26.0",
+                                "babylon": "6.18.0",
+                                "lodash": "4.17.4"
+                            }
+                        },
+                        "babel-traverse": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "babel-code-frame": "6.26.0",
+                                "babel-messages": "6.23.0",
+                                "babel-runtime": "6.26.0",
+                                "babel-types": "6.26.0",
+                                "babylon": "6.18.0",
+                                "debug": "2.6.9",
+                                "globals": "9.18.0",
+                                "invariant": "2.2.2",
+                                "lodash": "4.17.4"
+                            }
+                        },
+                        "babel-types": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "babel-runtime": "6.26.0",
+                                "esutils": "2.0.2",
+                                "lodash": "4.17.4",
+                                "to-fast-properties": "1.0.3"
+                            }
+                        },
+                        "babylon": {
+                            "version": "6.18.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "balanced-match": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "brace-expansion": {
+                            "version": "1.1.8",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "balanced-match": "1.0.0",
+                                "concat-map": "0.0.1"
+                            }
+                        },
+                        "braces": {
+                            "version": "1.8.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "expand-range": "1.8.2",
+                                "preserve": "0.2.0",
+                                "repeat-element": "1.1.2"
+                            }
+                        },
+                        "builtin-modules": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "caching-transform": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "md5-hex": "1.3.0",
+                                "mkdirp": "0.5.1",
+                                "write-file-atomic": "1.3.4"
+                            }
+                        },
+                        "camelcase": {
+                            "version": "1.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "center-align": {
+                            "version": "0.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "align-text": "0.1.4",
+                                "lazy-cache": "1.0.4"
+                            }
+                        },
+                        "chalk": {
+                            "version": "1.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "2.2.1",
+                                "escape-string-regexp": "1.0.5",
+                                "has-ansi": "2.0.0",
+                                "strip-ansi": "3.0.1",
+                                "supports-color": "2.0.0"
+                            }
+                        },
+                        "cliui": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "center-align": "0.1.3",
+                                "right-align": "0.1.3",
+                                "wordwrap": "0.0.2"
+                            },
+                            "dependencies": {
+                                "wordwrap": {
+                                    "version": "0.0.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "optional": true
+                                }
+                            }
+                        },
+                        "code-point-at": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "commondir": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "concat-map": {
+                            "version": "0.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "convert-source-map": {
+                            "version": "1.5.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "core-js": {
+                            "version": "2.5.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "cross-spawn": {
+                            "version": "4.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "lru-cache": "4.1.1",
+                                "which": "1.3.0"
+                            }
+                        },
+                        "debug": {
+                            "version": "2.6.9",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "debug-log": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "decamelize": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "default-require-extensions": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "strip-bom": "2.0.0"
+                            }
+                        },
+                        "detect-indent": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "repeating": "2.0.1"
+                            }
+                        },
+                        "error-ex": {
+                            "version": "1.3.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-arrayish": "0.2.1"
+                            }
+                        },
+                        "escape-string-regexp": {
+                            "version": "1.0.5",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "esutils": {
+                            "version": "2.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "execa": {
+                            "version": "0.7.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "cross-spawn": "5.1.0",
+                                "get-stream": "3.0.0",
+                                "is-stream": "1.1.0",
+                                "npm-run-path": "2.0.2",
+                                "p-finally": "1.0.0",
+                                "signal-exit": "3.0.2",
+                                "strip-eof": "1.0.0"
+                            },
+                            "dependencies": {
+                                "cross-spawn": {
+                                    "version": "5.1.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "lru-cache": "4.1.1",
+                                        "shebang-command": "1.2.0",
+                                        "which": "1.3.0"
+                                    }
+                                }
+                            }
+                        },
+                        "expand-brackets": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-posix-bracket": "0.1.1"
+                            }
+                        },
+                        "expand-range": {
+                            "version": "1.8.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "fill-range": "2.2.3"
+                            }
+                        },
+                        "extglob": {
+                            "version": "0.3.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "1.0.0"
+                            }
+                        },
+                        "filename-regex": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "fill-range": {
+                            "version": "2.2.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-number": "2.1.0",
+                                "isobject": "2.1.0",
+                                "randomatic": "1.1.7",
+                                "repeat-element": "1.1.2",
+                                "repeat-string": "1.6.1"
+                            }
+                        },
+                        "find-cache-dir": {
+                            "version": "0.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "commondir": "1.0.1",
+                                "mkdirp": "0.5.1",
+                                "pkg-dir": "1.0.0"
+                            }
+                        },
+                        "find-up": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "locate-path": "2.0.0"
+                            }
+                        },
+                        "for-in": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "for-own": {
+                            "version": "0.1.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "for-in": "1.0.2"
+                            }
+                        },
+                        "foreground-child": {
+                            "version": "1.5.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "cross-spawn": "4.0.2",
+                                "signal-exit": "3.0.2"
+                            }
+                        },
+                        "fs.realpath": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "get-caller-file": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "get-stream": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "glob": {
+                            "version": "7.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
+                            }
+                        },
+                        "glob-base": {
+                            "version": "0.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "glob-parent": "2.0.0",
+                                "is-glob": "2.0.1"
+                            }
+                        },
+                        "glob-parent": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-glob": "2.0.1"
+                            }
+                        },
+                        "globals": {
+                            "version": "9.18.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "graceful-fs": {
+                            "version": "4.1.11",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "handlebars": {
+                            "version": "4.0.11",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "async": "1.5.2",
+                                "optimist": "0.6.1",
+                                "source-map": "0.4.4",
+                                "uglify-js": "2.8.29"
+                            },
+                            "dependencies": {
+                                "source-map": {
+                                    "version": "0.4.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "amdefine": "1.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "has-ansi": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        },
+                        "has-flag": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "hosted-git-info": {
+                            "version": "2.5.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "imurmurhash": {
+                            "version": "0.1.4",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "inflight": {
+                            "version": "1.0.6",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "once": "1.4.0",
+                                "wrappy": "1.0.2"
+                            }
+                        },
+                        "inherits": {
+                            "version": "2.0.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "invariant": {
+                            "version": "2.2.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "loose-envify": "1.3.1"
+                            }
+                        },
+                        "invert-kv": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-arrayish": {
+                            "version": "0.2.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-buffer": {
+                            "version": "1.1.6",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-builtin-module": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "builtin-modules": "1.1.1"
+                            }
+                        },
+                        "is-dotfile": {
+                            "version": "1.0.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-equal-shallow": {
+                            "version": "0.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-primitive": "2.0.0"
+                            }
+                        },
+                        "is-extendable": {
+                            "version": "0.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-extglob": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-finite": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "1.0.1"
+                            }
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "1.0.1"
+                            }
+                        },
+                        "is-glob": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "1.0.0"
+                            }
+                        },
+                        "is-number": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            }
+                        },
+                        "is-posix-bracket": {
+                            "version": "0.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-primitive": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-stream": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-utf8": {
+                            "version": "0.2.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "isexe": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "isobject": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        },
+                        "istanbul-lib-coverage": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "istanbul-lib-hook": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "append-transform": "0.4.0"
+                            }
+                        },
+                        "istanbul-lib-instrument": {
+                            "version": "1.9.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "babel-generator": "6.26.0",
+                                "babel-template": "6.26.0",
+                                "babel-traverse": "6.26.0",
+                                "babel-types": "6.26.0",
+                                "babylon": "6.18.0",
+                                "istanbul-lib-coverage": "1.1.1",
+                                "semver": "5.4.1"
+                            }
+                        },
+                        "istanbul-lib-report": {
+                            "version": "1.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "istanbul-lib-coverage": "1.1.1",
+                                "mkdirp": "0.5.1",
+                                "path-parse": "1.0.5",
+                                "supports-color": "3.2.3"
+                            },
+                            "dependencies": {
+                                "supports-color": {
+                                    "version": "3.2.3",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "has-flag": "1.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "istanbul-lib-source-maps": {
+                            "version": "1.2.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "debug": "3.1.0",
+                                "istanbul-lib-coverage": "1.1.1",
+                                "mkdirp": "0.5.1",
+                                "rimraf": "2.6.2",
+                                "source-map": "0.5.7"
+                            },
+                            "dependencies": {
+                                "debug": {
+                                    "version": "3.1.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "ms": "2.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "istanbul-reports": {
+                            "version": "1.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "handlebars": "4.0.11"
+                            }
+                        },
+                        "js-tokens": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "jsesc": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        },
+                        "lazy-cache": {
+                            "version": "1.0.4",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "lcid": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "invert-kv": "1.0.0"
+                            }
+                        },
+                        "load-json-file": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1",
+                                "strip-bom": "2.0.0"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-locate": "2.0.0",
+                                "path-exists": "3.0.0"
+                            },
+                            "dependencies": {
+                                "path-exists": {
+                                    "version": "3.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "lodash": {
+                            "version": "4.17.4",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "longest": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "loose-envify": {
+                            "version": "1.3.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "js-tokens": "3.0.2"
+                            }
+                        },
+                        "lru-cache": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "pseudomap": "1.0.2",
+                                "yallist": "2.1.2"
+                            }
+                        },
+                        "md5-hex": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "md5-o-matic": "0.1.1"
+                            }
+                        },
+                        "md5-o-matic": {
+                            "version": "0.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "mem": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "mimic-fn": "1.1.0"
+                            }
+                        },
+                        "merge-source-map": {
+                            "version": "1.0.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "source-map": "0.5.7"
+                            }
+                        },
+                        "micromatch": {
+                            "version": "2.3.11",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "arr-diff": "2.0.0",
+                                "array-unique": "0.2.1",
+                                "braces": "1.8.5",
+                                "expand-brackets": "0.1.5",
+                                "extglob": "0.3.2",
+                                "filename-regex": "2.0.1",
+                                "is-extglob": "1.0.0",
+                                "is-glob": "2.0.1",
+                                "kind-of": "3.2.2",
+                                "normalize-path": "2.1.1",
+                                "object.omit": "2.0.1",
+                                "parse-glob": "3.0.4",
+                                "regex-cache": "0.4.4"
+                            }
+                        },
+                        "mimic-fn": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "1.1.8"
+                            }
+                        },
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "mkdirp": {
+                            "version": "0.5.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "minimist": "0.0.8"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "normalize-package-data": {
+                            "version": "2.4.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "hosted-git-info": "2.5.0",
+                                "is-builtin-module": "1.0.0",
+                                "semver": "5.4.1",
+                                "validate-npm-package-license": "3.0.1"
+                            }
+                        },
+                        "normalize-path": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "remove-trailing-separator": "1.1.0"
+                            }
+                        },
+                        "npm-run-path": {
+                            "version": "2.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "path-key": "2.0.1"
+                            }
+                        },
+                        "number-is-nan": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "object-assign": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "object.omit": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "for-own": "0.1.5",
+                                "is-extendable": "0.1.1"
+                            }
+                        },
+                        "once": {
+                            "version": "1.4.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "wrappy": "1.0.2"
+                            }
+                        },
+                        "optimist": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "minimist": "0.0.8",
+                                "wordwrap": "0.0.3"
+                            }
+                        },
+                        "os-homedir": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "os-locale": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "execa": "0.7.0",
+                                "lcid": "1.0.0",
+                                "mem": "1.1.0"
+                            }
+                        },
+                        "p-finally": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "p-limit": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "p-locate": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-limit": "1.1.0"
+                            }
+                        },
+                        "parse-glob": {
+                            "version": "3.0.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "glob-base": "0.3.0",
+                                "is-dotfile": "1.0.3",
+                                "is-extglob": "1.0.0",
+                                "is-glob": "2.0.1"
+                            }
+                        },
+                        "parse-json": {
+                            "version": "2.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "error-ex": "1.3.1"
+                            }
+                        },
+                        "path-exists": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "pinkie-promise": "2.0.1"
+                            }
+                        },
+                        "path-is-absolute": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "path-key": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "path-parse": {
+                            "version": "1.0.5",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "path-type": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "pify": "2.3.0",
+                                "pinkie-promise": "2.0.1"
+                            }
+                        },
+                        "pify": {
+                            "version": "2.3.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "pinkie": {
+                            "version": "2.0.4",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "pinkie-promise": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "pinkie": "2.0.4"
+                            }
+                        },
+                        "pkg-dir": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "find-up": "1.1.2"
+                            },
+                            "dependencies": {
+                                "find-up": {
+                                    "version": "1.1.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "path-exists": "2.1.0",
+                                        "pinkie-promise": "2.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "preserve": {
+                            "version": "0.2.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "pseudomap": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "randomatic": {
+                            "version": "1.1.7",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-number": "3.0.0",
+                                "kind-of": "4.0.0"
+                            },
+                            "dependencies": {
+                                "is-number": {
+                                    "version": "3.0.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "kind-of": "3.2.2"
+                                    },
+                                    "dependencies": {
+                                        "kind-of": {
+                                            "version": "3.2.2",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "is-buffer": "1.1.6"
+                                            }
+                                        }
+                                    }
+                                },
+                                "kind-of": {
+                                    "version": "4.0.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "1.1.6"
+                                    }
+                                }
+                            }
+                        },
+                        "read-pkg": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "load-json-file": "1.1.0",
+                                "normalize-package-data": "2.4.0",
+                                "path-type": "1.1.0"
+                            }
+                        },
+                        "read-pkg-up": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "find-up": "1.1.2",
+                                "read-pkg": "1.1.0"
+                            },
+                            "dependencies": {
+                                "find-up": {
+                                    "version": "1.1.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "path-exists": "2.1.0",
+                                        "pinkie-promise": "2.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "regenerator-runtime": {
+                            "version": "0.11.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "regex-cache": {
+                            "version": "0.4.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-equal-shallow": "0.1.3"
+                            }
+                        },
+                        "remove-trailing-separator": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "repeat-element": {
+                            "version": "1.1.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "repeat-string": {
+                            "version": "1.6.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "repeating": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-finite": "1.0.2"
+                            }
+                        },
+                        "require-directory": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "require-main-filename": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "resolve-from": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "right-align": {
+                            "version": "0.1.3",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "align-text": "0.1.4"
+                            }
+                        },
+                        "rimraf": {
+                            "version": "2.6.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "glob": "7.1.2"
+                            }
+                        },
+                        "semver": {
+                            "version": "5.4.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "set-blocking": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "shebang-command": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "shebang-regex": "1.0.0"
+                            }
+                        },
+                        "shebang-regex": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "signal-exit": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "slide": {
+                            "version": "1.1.6",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "source-map": {
+                            "version": "0.5.7",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "spawn-wrap": {
+                            "version": "1.4.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "foreground-child": "1.5.6",
+                                "mkdirp": "0.5.1",
+                                "os-homedir": "1.0.2",
+                                "rimraf": "2.6.2",
+                                "signal-exit": "3.0.2",
+                                "which": "1.3.0"
+                            }
+                        },
+                        "spdx-correct": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "spdx-license-ids": "1.2.2"
+                            }
+                        },
+                        "spdx-expression-parse": {
+                            "version": "1.0.4",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "spdx-license-ids": {
+                            "version": "1.2.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "string-width": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-fullwidth-code-point": "2.0.0",
+                                "strip-ansi": "4.0.0"
+                            },
+                            "dependencies": {
+                                "ansi-regex": {
+                                    "version": "3.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "is-fullwidth-code-point": {
+                                    "version": "2.0.0",
+                                    "bundled": true,
+                                    "dev": true
+                                },
+                                "strip-ansi": {
+                                    "version": "4.0.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "ansi-regex": "3.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "2.1.1"
+                            }
+                        },
+                        "strip-bom": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-utf8": "0.2.1"
+                            }
+                        },
+                        "strip-eof": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "test-exclude": {
+                            "version": "4.1.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "arrify": "1.0.1",
+                                "micromatch": "2.3.11",
+                                "object-assign": "4.1.1",
+                                "read-pkg-up": "1.0.1",
+                                "require-main-filename": "1.0.1"
+                            }
+                        },
+                        "to-fast-properties": {
+                            "version": "1.0.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "trim-right": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "uglify-js": {
+                            "version": "2.8.29",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "source-map": "0.5.7",
+                                "uglify-to-browserify": "1.0.2",
+                                "yargs": "3.10.0"
+                            },
+                            "dependencies": {
+                                "yargs": {
+                                    "version": "3.10.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "optional": true,
+                                    "requires": {
+                                        "camelcase": "1.2.1",
+                                        "cliui": "2.1.0",
+                                        "decamelize": "1.2.0",
+                                        "window-size": "0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "uglify-to-browserify": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "validate-npm-package-license": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "spdx-correct": "1.0.2",
+                                "spdx-expression-parse": "1.0.4"
+                            }
+                        },
+                        "which": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "isexe": "2.0.0"
+                            }
+                        },
+                        "which-module": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "window-size": {
+                            "version": "0.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        },
+                        "wordwrap": {
+                            "version": "0.0.3",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "wrap-ansi": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "string-width": "1.0.2",
+                                "strip-ansi": "3.0.1"
+                            },
+                            "dependencies": {
+                                "string-width": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "code-point-at": "1.1.0",
+                                        "is-fullwidth-code-point": "1.0.0",
+                                        "strip-ansi": "3.0.1"
+                                    }
+                                }
+                            }
+                        },
+                        "wrappy": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "write-file-atomic": {
+                            "version": "1.3.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "imurmurhash": "0.1.4",
+                                "slide": "1.1.6"
+                            }
+                        },
+                        "y18n": {
+                            "version": "3.2.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "yallist": {
+                            "version": "2.1.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "yargs": {
+                            "version": "10.0.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "cliui": "3.2.0",
+                                "decamelize": "1.2.0",
+                                "find-up": "2.1.0",
+                                "get-caller-file": "1.0.2",
+                                "os-locale": "2.1.0",
+                                "require-directory": "2.1.1",
+                                "require-main-filename": "1.0.1",
+                                "set-blocking": "2.0.0",
+                                "string-width": "2.1.1",
+                                "which-module": "2.0.0",
+                                "y18n": "3.2.1",
+                                "yargs-parser": "8.0.0"
+                            },
+                            "dependencies": {
+                                "cliui": {
+                                    "version": "3.2.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "string-width": "1.0.2",
+                                        "strip-ansi": "3.0.1",
+                                        "wrap-ansi": "2.1.0"
+                                    },
+                                    "dependencies": {
+                                        "string-width": {
+                                            "version": "1.0.2",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "code-point-at": "1.1.0",
+                                                "is-fullwidth-code-point": "1.0.0",
+                                                "strip-ansi": "3.0.1"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "yargs-parser": {
+                            "version": "8.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "camelcase": "4.1.0"
+                            },
+                            "dependencies": {
+                                "camelcase": {
+                                    "version": "4.1.0",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        }
                     }
                 },
                 "object-assign": {
@@ -3673,11 +4937,6 @@
                 "sntp": "2.1.0"
             }
         },
-        "header-case-normalizer": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/header-case-normalizer/-/header-case-normalizer-1.0.3.tgz",
-            "integrity": "sha1-+x1MjQxhadyrT3x+IbGGpqIqwME="
-        },
         "hoek": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
@@ -3765,23 +5024,6 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
-        "indent-string": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-            "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
-            "requires": {
-                "get-stdin": "4.0.1",
-                "minimist": "1.2.0",
-                "repeating": "1.1.3"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                }
-            }
-        },
         "indexof": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -3797,6 +5039,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "1.4.0",
                 "wrappy": "1.0.2"
@@ -3819,15 +5062,6 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
-        },
-        "inline-process-browser": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz",
-            "integrity": "sha1-RqYbFT3TybFiSxoAYm7bT39BTyI=",
-            "requires": {
-                "falafel": "1.2.0",
-                "through2": "0.6.5"
-            }
         },
         "inquirer": {
             "version": "3.3.0",
@@ -3864,11 +5098,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
             "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
-        },
-        "is-array": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
-            "integrity": "sha1-6YUMwsyGDDvAl36EzPDdRkWEJ5o="
         },
         "is-array-buffer-x": {
             "version": "1.7.0",
@@ -3908,11 +5137,6 @@
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
             "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
         },
-        "is-empty": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-0.0.1.tgz",
-            "integrity": "sha1-Cf3D1kndpZaRVsCFOpt2vXgcWjM="
-        },
         "is-falsey-x": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.1.tgz",
@@ -3925,6 +5149,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true,
             "requires": {
                 "number-is-nan": "1.0.1"
             }
@@ -4098,7 +5323,8 @@
         "isarray": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -4194,11 +5420,6 @@
                 "istanbul-lib-coverage": "1.2.0",
                 "semver": "5.3.0"
             }
-        },
-        "jkroso-type": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/jkroso-type/-/jkroso-type-1.1.1.tgz",
-            "integrity": "sha1-vEztbWxF/gdFKCuvyGqfjE/JzmE="
         },
         "js-tokens": {
             "version": "3.0.2",
@@ -4330,16 +5551,6 @@
                 "extsprintf": "1.3.0",
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
-            }
-        },
-        "jstransform": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-3.0.0.tgz",
-            "integrity": "sha1-olkats7o2XvzvoMNv6IxO4fNZAs=",
-            "requires": {
-                "base62": "0.1.1",
-                "esprima-fb": "3001.1.0-dev-harmony-fb",
-                "source-map": "0.1.31"
             }
         },
         "kettle": {
@@ -4982,7 +6193,8 @@
         "map-obj": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "dev": true
         },
         "math-clamp-x": {
             "version": "1.2.0",
@@ -5048,29 +6260,6 @@
                 "readable-stream": "1.0.34"
             }
         },
-        "meow": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-2.0.0.tgz",
-            "integrity": "sha1-j1MKjs9dQNP0tN+Tw0cpAPuiqPE=",
-            "requires": {
-                "camelcase-keys": "1.0.0",
-                "indent-string": "1.2.2",
-                "minimist": "1.2.0",
-                "object-assign": "1.0.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                },
-                "object-assign": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-1.0.0.tgz",
-                    "integrity": "sha1-5l3Idm07R7S4MHRlyDEdoDCwcKY="
-                }
-            }
-        },
         "merge-descriptors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -5114,6 +6303,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "dev": true,
             "requires": {
                 "brace-expansion": "1.1.8"
             }
@@ -5168,14 +6358,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "multiparty": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.1.3.tgz",
-            "integrity": "sha1-PEPH/LGJbhdGBDap3Qtu8WaOT5Q=",
-            "requires": {
-                "fd-slicer": "1.0.1"
-            }
         },
         "mustache": {
             "version": "2.3.0",
@@ -5324,11 +6506,6 @@
                     "dev": true
                 }
             }
-        },
-        "node-uuid": {
-            "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-            "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
         },
         "nomnom": {
             "version": "1.8.1",
@@ -8124,11 +9301,6 @@
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
             "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
-        "object-assign": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-            "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-        },
         "object-component": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
@@ -8151,11 +9323,6 @@
                 "to-object-x": "1.5.0",
                 "to-property-key-x": "2.0.2"
             }
-        },
-        "object-keys": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-            "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
         },
         "on-finished": {
             "version": "2.3.0",
@@ -8325,7 +9492,8 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -8354,11 +9522,6 @@
                 "pify": "2.3.0",
                 "pinkie-promise": "2.0.1"
             }
-        },
-        "pend": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
         },
         "performance-now": {
             "version": "2.1.0",
@@ -8625,620 +9788,6 @@
                 }
             }
         },
-        "pouchdb-all-dbs": {
-            "version": "git://github.com/the-t-in-rtf/pouchdb-all-dbs.git#010173f4afa7b752787885ee8606eda4c1f047bb",
-            "requires": {
-                "argsarray": "0.0.1",
-                "es3ify": "0.1.4",
-                "infusion": "3.0.0-dev.20171102T191539Z.c0636b395",
-                "inherits": "2.0.3",
-                "pouchdb-promise": "5.4.3",
-                "tiny-queue": "0.2.1"
-            },
-            "dependencies": {
-                "infusion": {
-                    "version": "3.0.0-dev.20171102T191539Z.c0636b395",
-                    "resolved": "https://registry.npmjs.org/infusion/-/infusion-3.0.0-dev.20171102T191539Z.c0636b395.tgz",
-                    "integrity": "sha1-5SYGaY+VFWIB39mJUf5wBKpzntk=",
-                    "requires": {
-                        "fluid-resolve": "1.3.0"
-                    }
-                }
-            }
-        },
-        "pouchdb-auth": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/pouchdb-auth/-/pouchdb-auth-2.1.1.tgz",
-            "integrity": "sha1-X04iFvQk3h1cpQ9LTOt2Jc1YllQ=",
-            "requires": {
-                "base64url": "1.0.6",
-                "couchdb-calculate-session-id": "1.1.2",
-                "crypto-lite": "0.1.0",
-                "pouchdb-bulkdocs-wrapper": "1.0.2",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-promise": "5.4.3",
-                "pouchdb-req-http-query": "1.0.4",
-                "pouchdb-system-db": "1.0.4",
-                "pouchdb-validation": "1.2.1",
-                "pouchdb-wrappers": "1.3.6",
-                "promise-nodify": "1.0.2",
-                "secure-random": "1.1.1"
-            }
-        },
-        "pouchdb-bulkdocs-wrapper": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pouchdb-bulkdocs-wrapper/-/pouchdb-bulkdocs-wrapper-1.0.2.tgz",
-            "integrity": "sha1-DDYlGVg3F5IAYDKIEslHtqGvwhE=",
-            "requires": {
-                "pouchdb-promise": "0.0.0"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz",
-                    "integrity": "sha1-WYXsI8tv8aWDTMZEezxe8BD9Mho="
-                },
-                "lie": {
-                    "version": "2.7.7",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-2.7.7.tgz",
-                    "integrity": "sha1-fPlZvtSJWbBi8Drka7vzqsMCark=",
-                    "requires": {
-                        "immediate": "3.0.6"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-0.0.0.tgz",
-                    "integrity": "sha1-PAFOYndm2UW+PycOB5p9tNLRmCc=",
-                    "requires": {
-                        "bluebird": "1.2.4",
-                        "lie": "2.7.7"
-                    }
-                }
-            }
-        },
-        "pouchdb-changeslike-wrapper": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/pouchdb-changeslike-wrapper/-/pouchdb-changeslike-wrapper-1.0.1.tgz",
-            "integrity": "sha1-OQuapX/hfyL/OmKBRh9q8OBAcTU="
-        },
-        "pouchdb-collate": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-1.2.0.tgz",
-            "integrity": "sha1-yuO4MPyhJLf5fSMEbk+qMR7Dgow="
-        },
-        "pouchdb-extend": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/pouchdb-extend/-/pouchdb-extend-0.1.2.tgz",
-            "integrity": "sha1-0c5RG/cE7S4p979CikFqz/+hJLg="
-        },
-        "pouchdb-find": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/pouchdb-find/-/pouchdb-find-0.10.3.tgz",
-            "integrity": "sha1-tg1B4doSPGMlzp1/P4bMOGQgt6Y=",
-            "requires": {
-                "argsarray": "0.0.1",
-                "debug": "2.6.9",
-                "inherits": "2.0.3",
-                "is-array": "1.0.1",
-                "pouchdb-collate": "1.2.0",
-                "pouchdb-extend": "0.1.2",
-                "pouchdb-promise": "5.4.0",
-                "pouchdb-upsert": "2.0.2",
-                "spark-md5": "0.0.5"
-            },
-            "dependencies": {
-                "base62": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.1.tgz",
-                    "integrity": "sha1-laWiI1CwpVfz8IEkf8LDmIA+yww="
-                },
-                "es3ify": {
-                    "version": "0.2.2",
-                    "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.2.2.tgz",
-                    "integrity": "sha1-Xa4+ZQ5b42hLiAZlE9Uo0JJimGI=",
-                    "requires": {
-                        "esprima": "2.7.3",
-                        "jstransform": "11.0.3",
-                        "through": "2.3.8"
-                    }
-                },
-                "esprima": {
-                    "version": "2.7.3",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                    "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-                },
-                "jstransform": {
-                    "version": "11.0.3",
-                    "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-                    "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-                    "requires": {
-                        "base62": "1.2.1",
-                        "commoner": "0.10.8",
-                        "esprima-fb": "15001.1.0-dev-harmony-fb",
-                        "object-assign": "2.1.1",
-                        "source-map": "0.4.4"
-                    },
-                    "dependencies": {
-                        "esprima-fb": {
-                            "version": "15001.1.0-dev-harmony-fb",
-                            "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-                            "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
-                        }
-                    }
-                },
-                "lie": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.4.tgz",
-                    "integrity": "sha1-vHrh6+fxyN45r9zU94kHa0ew9jQ=",
-                    "requires": {
-                        "es3ify": "0.2.2",
-                        "immediate": "3.0.6",
-                        "inline-process-browser": "1.0.0",
-                        "unreachable-branch-transform": "0.3.0"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-5.4.0.tgz",
-                    "integrity": "sha1-4nesa9oayFBFl6u1xDp8Op5Whm8=",
-                    "requires": {
-                        "lie": "3.0.4"
-                    }
-                },
-                "source-map": {
-                    "version": "0.4.4",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                    "requires": {
-                        "amdefine": "1.0.1"
-                    }
-                }
-            }
-        },
-        "pouchdb-list": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/pouchdb-list/-/pouchdb-list-1.1.0.tgz",
-            "integrity": "sha1-PkYZk33XaqiQnqyT/ynAe/C5tFE=",
-            "requires": {
-                "couchdb-objects": "1.0.7",
-                "couchdb-render": "1.0.1",
-                "extend": "3.0.1",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-promise": "0.0.0",
-                "pouchdb-req-http-query": "1.0.4",
-                "promise-nodify": "1.0.2"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz",
-                    "integrity": "sha1-WYXsI8tv8aWDTMZEezxe8BD9Mho="
-                },
-                "lie": {
-                    "version": "2.7.7",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-2.7.7.tgz",
-                    "integrity": "sha1-fPlZvtSJWbBi8Drka7vzqsMCark=",
-                    "requires": {
-                        "immediate": "3.0.6"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-0.0.0.tgz",
-                    "integrity": "sha1-PAFOYndm2UW+PycOB5p9tNLRmCc=",
-                    "requires": {
-                        "bluebird": "1.2.4",
-                        "lie": "2.7.7"
-                    }
-                }
-            }
-        },
-        "pouchdb-plugin-error": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/pouchdb-plugin-error/-/pouchdb-plugin-error-1.0.1.tgz",
-            "integrity": "sha1-xy8GAUEkqfqQOPyO2ifFizSIBco="
-        },
-        "pouchdb-promise": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-5.4.3.tgz",
-            "integrity": "sha1-Mx1nCxmJ1aA/JogRIU8n9UFQyys=",
-            "requires": {
-                "lie": "3.0.4"
-            },
-            "dependencies": {
-                "base62": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.1.tgz",
-                    "integrity": "sha1-laWiI1CwpVfz8IEkf8LDmIA+yww="
-                },
-                "es3ify": {
-                    "version": "0.2.2",
-                    "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.2.2.tgz",
-                    "integrity": "sha1-Xa4+ZQ5b42hLiAZlE9Uo0JJimGI=",
-                    "requires": {
-                        "esprima": "2.7.3",
-                        "jstransform": "11.0.3",
-                        "through": "2.3.8"
-                    }
-                },
-                "esprima": {
-                    "version": "2.7.3",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                    "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-                },
-                "jstransform": {
-                    "version": "11.0.3",
-                    "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-                    "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-                    "requires": {
-                        "base62": "1.2.1",
-                        "commoner": "0.10.8",
-                        "esprima-fb": "15001.1.0-dev-harmony-fb",
-                        "object-assign": "2.1.1",
-                        "source-map": "0.4.4"
-                    },
-                    "dependencies": {
-                        "esprima-fb": {
-                            "version": "15001.1.0-dev-harmony-fb",
-                            "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-                            "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
-                        }
-                    }
-                },
-                "lie": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.4.tgz",
-                    "integrity": "sha1-vHrh6+fxyN45r9zU94kHa0ew9jQ=",
-                    "requires": {
-                        "es3ify": "0.2.2",
-                        "immediate": "3.0.6",
-                        "inline-process-browser": "1.0.0",
-                        "unreachable-branch-transform": "0.3.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.4.4",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-                    "requires": {
-                        "amdefine": "1.0.1"
-                    }
-                }
-            }
-        },
-        "pouchdb-replicator": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/pouchdb-replicator/-/pouchdb-replicator-2.1.3.tgz",
-            "integrity": "sha1-pIfk/sCW+FSA+D6aKh8PuMpMFbk=",
-            "requires": {
-                "equals": "1.0.5",
-                "extend": "1.3.0",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-promise": "0.0.0",
-                "pouchdb-system-db": "1.0.4",
-                "pouchdb-validation": "1.2.1",
-                "promise-nodify": "1.0.2",
-                "random-uuid-v4": "0.0.4"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz",
-                    "integrity": "sha1-WYXsI8tv8aWDTMZEezxe8BD9Mho="
-                },
-                "extend": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-                    "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-                },
-                "lie": {
-                    "version": "2.7.7",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-2.7.7.tgz",
-                    "integrity": "sha1-fPlZvtSJWbBi8Drka7vzqsMCark=",
-                    "requires": {
-                        "immediate": "3.0.6"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-0.0.0.tgz",
-                    "integrity": "sha1-PAFOYndm2UW+PycOB5p9tNLRmCc=",
-                    "requires": {
-                        "bluebird": "1.2.4",
-                        "lie": "2.7.7"
-                    }
-                }
-            }
-        },
-        "pouchdb-req-http-query": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/pouchdb-req-http-query/-/pouchdb-req-http-query-1.0.4.tgz",
-            "integrity": "sha1-d+c1xBBvO5clx9VZWakyM2TdI3E=",
-            "requires": {
-                "extend": "1.3.0",
-                "header-case-normalizer": "1.0.3",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-promise": "0.0.0",
-                "xmlhttprequest-cookie": "0.9.5"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz",
-                    "integrity": "sha1-WYXsI8tv8aWDTMZEezxe8BD9Mho="
-                },
-                "extend": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-                    "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-                },
-                "lie": {
-                    "version": "2.7.7",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-2.7.7.tgz",
-                    "integrity": "sha1-fPlZvtSJWbBi8Drka7vzqsMCark=",
-                    "requires": {
-                        "immediate": "3.0.6"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-0.0.0.tgz",
-                    "integrity": "sha1-PAFOYndm2UW+PycOB5p9tNLRmCc=",
-                    "requires": {
-                        "bluebird": "1.2.4",
-                        "lie": "2.7.7"
-                    }
-                }
-            }
-        },
-        "pouchdb-rewrite": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/pouchdb-rewrite/-/pouchdb-rewrite-1.0.7.tgz",
-            "integrity": "sha1-P5d+PfTJ5Uz3Xoct6ekR+HeQwtg=",
-            "requires": {
-                "couchdb-objects": "1.0.7",
-                "extend": "1.3.0",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-req-http-query": "1.0.4",
-                "pouchdb-route": "1.0.3",
-                "promise-nodify": "1.0.2"
-            },
-            "dependencies": {
-                "extend": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-                    "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-                }
-            }
-        },
-        "pouchdb-route": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/pouchdb-route/-/pouchdb-route-1.0.3.tgz",
-            "integrity": "sha1-5QIbdorffh9HUNlNlQ9Uqf1rU0A=",
-            "requires": {
-                "extend": "1.3.0",
-                "pouchdb-plugin-error": "1.0.1"
-            },
-            "dependencies": {
-                "extend": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-                    "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-                }
-            }
-        },
-        "pouchdb-security": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/pouchdb-security/-/pouchdb-security-1.2.6.tgz",
-            "integrity": "sha1-OE/SiagD5xqYhTULq7SsERBEOQQ=",
-            "requires": {
-                "extend": "1.3.0",
-                "pouchdb-bulkdocs-wrapper": "1.0.2",
-                "pouchdb-changeslike-wrapper": "1.0.1",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-promise": "0.0.0",
-                "pouchdb-req-http-query": "1.0.4",
-                "pouchdb-wrappers": "1.3.6",
-                "promise-nodify": "1.0.2"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz",
-                    "integrity": "sha1-WYXsI8tv8aWDTMZEezxe8BD9Mho="
-                },
-                "extend": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-                    "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
-                },
-                "lie": {
-                    "version": "2.7.7",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-2.7.7.tgz",
-                    "integrity": "sha1-fPlZvtSJWbBi8Drka7vzqsMCark=",
-                    "requires": {
-                        "immediate": "3.0.6"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-0.0.0.tgz",
-                    "integrity": "sha1-PAFOYndm2UW+PycOB5p9tNLRmCc=",
-                    "requires": {
-                        "bluebird": "1.2.4",
-                        "lie": "2.7.7"
-                    }
-                }
-            }
-        },
-        "pouchdb-show": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/pouchdb-show/-/pouchdb-show-1.0.8.tgz",
-            "integrity": "sha1-lQz8KHcMCqLbrJbydcgJU/5aJeY=",
-            "requires": {
-                "couchdb-objects": "1.0.7",
-                "couchdb-render": "1.0.1",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-promise": "0.0.0",
-                "pouchdb-req-http-query": "1.0.4",
-                "promise-nodify": "1.0.2"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz",
-                    "integrity": "sha1-WYXsI8tv8aWDTMZEezxe8BD9Mho="
-                },
-                "lie": {
-                    "version": "2.7.7",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-2.7.7.tgz",
-                    "integrity": "sha1-fPlZvtSJWbBi8Drka7vzqsMCark=",
-                    "requires": {
-                        "immediate": "3.0.6"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-0.0.0.tgz",
-                    "integrity": "sha1-PAFOYndm2UW+PycOB5p9tNLRmCc=",
-                    "requires": {
-                        "bluebird": "1.2.4",
-                        "lie": "2.7.7"
-                    }
-                }
-            }
-        },
-        "pouchdb-size": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/pouchdb-size/-/pouchdb-size-1.2.2.tgz",
-            "integrity": "sha1-EpFfE+nSQcsOcKZsGOfV/2mfEKg=",
-            "requires": {
-                "bluebird": "2.11.0",
-                "get-folder-size": "0.1.1",
-                "pouchdb-wrappers": "1.3.6",
-                "promise-nodify": "1.0.2"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-                    "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-                }
-            }
-        },
-        "pouchdb-system-db": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/pouchdb-system-db/-/pouchdb-system-db-1.0.4.tgz",
-            "integrity": "sha1-FQGNhxnwK8/Zy2nnJDuLCUF0uqI=",
-            "requires": {
-                "pouchdb-changeslike-wrapper": "1.0.1",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-security": "1.2.6",
-                "pouchdb-wrappers": "1.3.6"
-            }
-        },
-        "pouchdb-update": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/pouchdb-update/-/pouchdb-update-1.0.8.tgz",
-            "integrity": "sha1-l+k9W619jSg+DRTeZTvOJMNheLQ=",
-            "requires": {
-                "couchdb-eval": "1.0.6",
-                "couchdb-objects": "1.0.7",
-                "couchdb-resp-completer": "1.0.3",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-promise": "0.0.0",
-                "pouchdb-req-http-query": "1.0.4",
-                "promise-nodify": "1.0.2"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz",
-                    "integrity": "sha1-WYXsI8tv8aWDTMZEezxe8BD9Mho="
-                },
-                "lie": {
-                    "version": "2.7.7",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-2.7.7.tgz",
-                    "integrity": "sha1-fPlZvtSJWbBi8Drka7vzqsMCark=",
-                    "requires": {
-                        "immediate": "3.0.6"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-0.0.0.tgz",
-                    "integrity": "sha1-PAFOYndm2UW+PycOB5p9tNLRmCc=",
-                    "requires": {
-                        "bluebird": "1.2.4",
-                        "lie": "2.7.7"
-                    }
-                }
-            }
-        },
-        "pouchdb-upsert": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/pouchdb-upsert/-/pouchdb-upsert-2.0.2.tgz",
-            "integrity": "sha1-x0bMmUXlLYx45C9jreBmZ3eZZxI=",
-            "requires": {
-                "pouchdb-promise": "5.4.3"
-            }
-        },
-        "pouchdb-validation": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/pouchdb-validation/-/pouchdb-validation-1.2.1.tgz",
-            "integrity": "sha1-YJISgmFbYNd/UYU3+QzAeRBpwCs=",
-            "requires": {
-                "couchdb-eval": "1.0.6",
-                "couchdb-objects": "1.0.7",
-                "pouchdb-bulkdocs-wrapper": "1.0.2",
-                "pouchdb-plugin-error": "1.0.1",
-                "pouchdb-promise": "0.0.0",
-                "pouchdb-wrappers": "1.3.6",
-                "random-uuid-v4": "0.0.4"
-            },
-            "dependencies": {
-                "bluebird": {
-                    "version": "1.2.4",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.4.tgz",
-                    "integrity": "sha1-WYXsI8tv8aWDTMZEezxe8BD9Mho="
-                },
-                "lie": {
-                    "version": "2.7.7",
-                    "resolved": "https://registry.npmjs.org/lie/-/lie-2.7.7.tgz",
-                    "integrity": "sha1-fPlZvtSJWbBi8Drka7vzqsMCark=",
-                    "requires": {
-                        "immediate": "3.0.6"
-                    }
-                },
-                "pouchdb-promise": {
-                    "version": "0.0.0",
-                    "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-0.0.0.tgz",
-                    "integrity": "sha1-PAFOYndm2UW+PycOB5p9tNLRmCc=",
-                    "requires": {
-                        "bluebird": "1.2.4",
-                        "lie": "2.7.7"
-                    }
-                }
-            }
-        },
-        "pouchdb-vhost": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pouchdb-vhost/-/pouchdb-vhost-1.0.2.tgz",
-            "integrity": "sha1-URUX2zx/X9WQ4+6LIOPvnolAD9Y=",
-            "requires": {
-                "pouchdb-route": "1.0.3",
-                "promise-nodify": "1.0.2"
-            }
-        },
-        "pouchdb-wrappers": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/pouchdb-wrappers/-/pouchdb-wrappers-1.3.6.tgz",
-            "integrity": "sha1-8+EbZk6JqbMX54XJYVHMsXNvJdA=",
-            "requires": {
-                "promise-nodify": "1.0.2"
-            }
-        },
         "prebuild": {
             "version": "7.6.0",
             "resolved": "https://registry.npmjs.org/prebuild/-/prebuild-7.6.0.tgz",
@@ -9498,11 +10047,6 @@
             "integrity": "sha1-xDjKLKM+OSdnHbSracDlL5NqTw8=",
             "dev": true
         },
-        "private": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-            "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
-        },
         "process-nextick-args": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -9513,11 +10057,6 @@
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
             "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
             "dev": true
-        },
-        "promise-nodify": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/promise-nodify/-/promise-nodify-1.0.2.tgz",
-            "integrity": "sha1-DQ+xQ8M0ALAGG0flgSV1VwR9TFo="
         },
         "property-is-enumerable-x": {
             "version": "1.1.0",
@@ -9562,11 +10101,6 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
-        "q": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-        },
         "qs": {
             "version": "6.5.1",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -9576,11 +10110,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
             "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
-        },
-        "random-uuid-v4": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/random-uuid-v4/-/random-uuid-v4-0.0.4.tgz",
-            "integrity": "sha1-ShibBWkJjbt6Q1sJVAH4geNh62o="
         },
         "range-parser": {
             "version": "1.2.0",
@@ -9641,6 +10170,7 @@
             "version": "1.0.34",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+            "dev": true,
             "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -9673,29 +10203,6 @@
                     "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
                     "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
                     "dev": true
-                }
-            }
-        },
-        "recast": {
-            "version": "0.11.23",
-            "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-            "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-            "requires": {
-                "ast-types": "0.9.6",
-                "esprima": "3.1.3",
-                "private": "0.1.8",
-                "source-map": "0.5.7"
-            },
-            "dependencies": {
-                "esprima": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-                    "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
                 }
             }
         },
@@ -9746,14 +10253,6 @@
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
-        },
-        "repeating": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-            "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-            "requires": {
-                "is-finite": "1.0.2"
-            }
         },
         "replace-comments-x": {
             "version": "2.0.0",
@@ -9914,11 +10413,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "secure-random": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.1.tgz",
-            "integrity": "sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo="
         },
         "semver": {
             "version": "5.3.0",
@@ -10190,14 +10684,6 @@
                 }
             }
         },
-        "source-map": {
-            "version": "0.1.31",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
-            "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
-            "requires": {
-                "amdefine": "1.0.1"
-            }
-        },
         "source-map-support": {
             "version": "0.2.10",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
@@ -10217,11 +10703,6 @@
                     }
                 }
             }
-        },
-        "spark-md5": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-0.0.5.tgz",
-            "integrity": "sha1-kx2l47lR0GUn6bfZDf/1eLb83I4="
         },
         "spawn-args": {
             "version": "0.2.0",
@@ -10794,21 +11275,18 @@
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
         },
         "through2": {
             "version": "0.6.5",
             "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+            "dev": true,
             "requires": {
                 "readable-stream": "1.0.34",
                 "xtend": "4.0.1"
             }
-        },
-        "tiny-queue": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/tiny-queue/-/tiny-queue-0.2.1.tgz",
-            "integrity": "sha1-JaZ/LG4lOyypQZd7XvdELvl6YEY="
         },
         "tmp": {
             "version": "0.0.33",
@@ -11040,7 +11518,8 @@
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
         },
         "uglify-js": {
             "version": "2.8.29",
@@ -11111,44 +11590,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-        },
-        "unreachable-branch-transform": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
-            "integrity": "sha1-2ZzExudG0mSSiEW2EdtUsPNHTKo=",
-            "requires": {
-                "esmangle-evaluator": "1.0.1",
-                "recast": "0.10.43",
-                "through2": "0.6.5"
-            },
-            "dependencies": {
-                "ast-types": {
-                    "version": "0.8.15",
-                    "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
-                    "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI="
-                },
-                "esprima-fb": {
-                    "version": "15001.1001.0-dev-harmony-fb",
-                    "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-                    "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
-                },
-                "recast": {
-                    "version": "0.10.43",
-                    "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
-                    "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
-                    "requires": {
-                        "ast-types": "0.8.15",
-                        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                        "private": "0.1.8",
-                        "source-map": "0.5.7"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-                }
-            }
         },
         "unzipper": {
             "version": "0.8.14",
@@ -11399,19 +11840,6 @@
             "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
             "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
             "dev": true
-        },
-        "xmlhttprequest": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-            "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
-        },
-        "xmlhttprequest-cookie": {
-            "version": "0.9.5",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest-cookie/-/xmlhttprequest-cookie-0.9.5.tgz",
-            "integrity": "sha1-5j2fQcUvCth+Csgf1JF03M64XfA=",
-            "requires": {
-                "xmlhttprequest": "1.8.0"
-            }
         },
         "xmlhttprequest-ssl": {
             "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "body-parser": "1.18.3",
         "express": "4.16.3",
-        "express-pouchdb": "git://github.com/the-t-in-rtf/express-pouchdb.git#299582cd5bbe33e4057135413c34b72c2c8a7167",
+        "express-pouchdb": "git://github.com/the-t-in-rtf/express-pouchdb.git#aa1ebf4d7b93353d901c3b4f2c706db4967a9db9",
         "gpii-express": "1.0.13",
         "graceful-fs": "4.1.11",
         "infusion": "3.0.0-dev.20180222T160835Z.6e1311a",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "body-parser": "1.18.3",
         "express": "4.16.3",
-        "express-pouchdb": "git://github.com/the-t-in-rtf/express-pouchdb.git#aa1ebf4d7b93353d901c3b4f2c706db4967a9db9",
+        "@the-t-in-rtf/express-pouchdb": "4.0.0-20180523-1217",
         "gpii-express": "1.0.13",
         "graceful-fs": "4.1.11",
         "infusion": "3.0.0-dev.20180222T160835Z.6e1311a",

--- a/src/js/pouch-express.js
+++ b/src/js/pouch-express.js
@@ -28,7 +28,7 @@ var os             = require("os");
 var fs             = require("fs");
 var memdown        = require("memdown");
 
-var expressPouchdb = require("express-pouchdb");
+var expressPouchdb = require("@the-t-in-rtf/express-pouchdb");
 
 var PouchDB        = require("pouchdb");
 


### PR DESCRIPTION
See [GPII-3068](https://issues.gpii.net/browse/GPII-3068) for details.